### PR TITLE
feat: support futopt spread contracts & trial matching (#607/#609)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,30 @@ The library is an isomorphic Python client that supports REST API and WebSocket.
 client = RestClient(api_key = 'YOUR_API_KEY')
 stock = client.stock  # Stock REST API client
 print(stock.intraday.quote(symbol="2330"))
+
+futopt = client.futopt  # Futures & Options REST API client
 ```
+
+#### Futures & Options spread contracts
+
+Spread (combination) contract symbols contain a `/` separator (e.g. `MXFA6/C6`).
+The symbol is URL-encoded automatically, so you can pass it as-is. Their quotes
+may carry **negative** prices, and the quote response includes trial-matching
+(試搓) fields `lastTrial` / `isTrial`.
+
+```py
+# List tradable spread contracts (pass the string "true", not a Python bool)
+print(futopt.intraday.tickers(type="FUTURE", isSpread="true"))
+
+# Quote a spread contract
+print(futopt.intraday.quote(symbol="MXFA6/C6"))
+
+# Fetch trial-matching (試搓) trade ticks
+print(futopt.intraday.trades(symbol="TXFA6", isTrial=True))
+```
+
+The futopt WebSocket `books` channel may also include an extended 6th order-book
+level (`derivedBid` / `derivedAsk`) and an `isTrial` flag during the trial session.
 
 ### WebSocket API
 

--- a/fugle_marketdata/rest/futopt/historical.py
+++ b/fugle_marketdata/rest/futopt/historical.py
@@ -1,12 +1,12 @@
+from urllib.parse import quote as urlquote
+
 from ..base_rest import BaseRest
 
 class Historical(BaseRest):
     def daily(self, **params):
-        symbol = params.pop('symbol')
+        symbol = urlquote(params.pop('symbol'), safe='')
         return self.request(f"historical/daily/{symbol}", **params)
-    def candles(self, **params):
-        symbol = params.pop('symbol')
-        return self.request(f"historical/candles/{symbol}", **params)
-    
 
-    
+    def candles(self, **params):
+        symbol = urlquote(params.pop('symbol'), safe='')
+        return self.request(f"historical/candles/{symbol}", **params)

--- a/fugle_marketdata/rest/futopt/intraday.py
+++ b/fugle_marketdata/rest/futopt/intraday.py
@@ -1,28 +1,30 @@
+from urllib.parse import quote as urlquote
+
 from ..base_rest import BaseRest
 
 class Intraday(BaseRest):
     def products(self, **params):
         return self.request(f"intraday/products", **params)
-    
+
     def tickers(self, **params):
         return self.request(f"intraday/tickers", **params)
-    
+
     def ticker(self, **params):
-        symbol = params.pop('symbol')
+        symbol = urlquote(params.pop('symbol'), safe='')
         return self.request(f"intraday/ticker/{symbol}", **params)
-    
+
     def quote(self, **params):
-        symbol = params.pop('symbol')
+        symbol = urlquote(params.pop('symbol'), safe='')
         return self.request(f"intraday/quote/{symbol}", **params)
-    
+
     def candles(self, **params):
-        symbol = params.pop('symbol')
+        symbol = urlquote(params.pop('symbol'), safe='')
         return self.request(f"intraday/candles/{symbol}", **params)
-    
+
     def trades(self, **params):
-        symbol = params.pop('symbol')
+        symbol = urlquote(params.pop('symbol'), safe='')
         return self.request(f"intraday/trades/{symbol}", **params)
-    
+
     def volumes(self, **params):
-        symbol = params.pop('symbol')
+        symbol = urlquote(params.pop('symbol'), safe='')
         return self.request(f"intraday/volumes/{symbol}", **params)

--- a/tests/test_base_rest.py
+++ b/tests/test_base_rest.py
@@ -36,6 +36,7 @@ class TestBaseRest:
         
         with patch("requests.get") as mock_get:
             mock_response = Mock()
+            mock_response.status_code = 200
             mock_response.json.return_value = expected_data
             mock_get.return_value = mock_response
             
@@ -53,6 +54,7 @@ class TestBaseRest:
         
         with patch("requests.get") as mock_get:
             mock_response = Mock()
+            mock_response.status_code = 200
             mock_response.json.side_effect = ValueError("No JSON object could be decoded")
             mock_response.text = invalid_response_text
             mock_get.return_value = mock_response
@@ -60,7 +62,7 @@ class TestBaseRest:
             with pytest.raises(Exception) as exc_info:
                 base_rest_with_api_key.request("/test")
             
-            assert "An unexpected data error occurred.\nPlease try again later. If the issue persists, please contact support at  (tech.support@fugle.tw)" in str(exc_info.value)
+            assert "Failed to parse JSON response" in str(exc_info.value)
 
     def test_json_decode_error_with_different_error_types(self, base_rest_with_api_key):
         """測試不同類型的 JSON 解碼錯誤"""
@@ -68,6 +70,7 @@ class TestBaseRest:
         
         with patch("requests.get") as mock_get:
             mock_response = Mock()
+            mock_response.status_code = 200
             mock_response.json.side_effect = ValueError("Expecting "," delimiter")
             mock_response.text = response_text
             mock_get.return_value = mock_response
@@ -75,12 +78,13 @@ class TestBaseRest:
             with pytest.raises(Exception) as exc_info:
                 base_rest_with_api_key.request("/test")
             
-            assert "An unexpected data error occurred.\nPlease try again later. If the issue persists, please contact support at  (tech.support@fugle.tw)" in str(exc_info.value)
+            assert "Failed to parse JSON response" in str(exc_info.value)
 
     def test_empty_response_text_in_error(self, base_rest_with_api_key):
         """測試空的回應內容時的錯誤處理"""
         with patch("requests.get") as mock_get:
             mock_response = Mock()
+            mock_response.status_code = 200
             mock_response.json.side_effect = ValueError("No JSON object could be decoded")
             mock_response.text = ""
             mock_get.return_value = mock_response
@@ -88,7 +92,7 @@ class TestBaseRest:
             with pytest.raises(Exception) as exc_info:
                 base_rest_with_api_key.request("/test")
             
-            assert "An unexpected data error occurred.\nPlease try again later. If the issue persists, please contact support at  (tech.support@fugle.tw)" in str(exc_info.value)
+            assert "Failed to parse JSON response" in str(exc_info.value)
 
     def test_real_world_error_scenarios(self, base_rest_with_api_key):
         """測試真實世界的錯誤情境"""
@@ -96,6 +100,7 @@ class TestBaseRest:
         
         with patch("requests.get") as mock_get:
             mock_response = Mock()
+            mock_response.status_code = 200
             mock_response.json.side_effect = ValueError("No JSON object could be decoded")
             mock_response.text = html_response
             mock_get.return_value = mock_response
@@ -103,7 +108,7 @@ class TestBaseRest:
             with pytest.raises(Exception) as exc_info:
                 base_rest_with_api_key.request("/test")
             
-            assert "An unexpected data error occurred.\nPlease try again later. If the issue persists, please contact support at  (tech.support@fugle.tw)" in str(exc_info.value)
+            assert "Failed to parse JSON response" in str(exc_info.value)
 
     def test_partial_json_response_error(self, base_rest_with_api_key):
         """測試部分 JSON 回應錯誤"""
@@ -111,6 +116,7 @@ class TestBaseRest:
         
         with patch("requests.get") as mock_get:
             mock_response = Mock()
+            mock_response.status_code = 200
             mock_response.json.side_effect = ValueError("Unterminated string")
             mock_response.text = partial_json
             mock_get.return_value = mock_response
@@ -118,12 +124,13 @@ class TestBaseRest:
             with pytest.raises(Exception) as exc_info:
                 base_rest_with_api_key.request("/test")
             
-            assert "An unexpected data error occurred.\nPlease try again later. If the issue persists, please contact support at  (tech.support@fugle.tw)" in str(exc_info.value)
+            assert "Failed to parse JSON response" in str(exc_info.value)
 
     def test_integration_with_stock_client(self, base_rest_with_api_key):
         """測試與 Stock Client 的集成"""
         with patch("requests.get") as mock_get:
             mock_response = Mock()
+            mock_response.status_code = 200
             mock_response.json.side_effect = ValueError("Invalid JSON")
             mock_response.text = "<html>Error Page</html>"
             mock_get.return_value = mock_response
@@ -131,12 +138,13 @@ class TestBaseRest:
             with pytest.raises(Exception) as exc_info:
                 base_rest_with_api_key.request("/stock/intraday/quote/2330")
             
-            assert "An unexpected data error occurred.\nPlease try again later. If the issue persists, please contact support at  (tech.support@fugle.tw)" in str(exc_info.value)
+            assert "Failed to parse JSON response" in str(exc_info.value)
 
     def test_json_content_type_mismatch(self, base_rest_with_api_key):
         """測試當伺服器回傳非 JSON 內容類型時的處理"""
         with patch("requests.get") as mock_get:
             mock_response = Mock()
+            mock_response.status_code = 200
             mock_response.json.side_effect = ValueError("No JSON object could be decoded")
             mock_response.text = "<xml><error>Service unavailable</error></xml>"
             mock_get.return_value = mock_response
@@ -144,12 +152,13 @@ class TestBaseRest:
             with pytest.raises(Exception) as exc_info:
                 base_rest_with_api_key.request("/test")
             
-            assert "An unexpected data error occurred.\nPlease try again later. If the issue persists, please contact support at  (tech.support@fugle.tw)" in str(exc_info.value)
+            assert "Failed to parse JSON response" in str(exc_info.value)
 
     def test_network_timeout_with_partial_response(self, base_rest_with_api_key):
         """測試網路超時導致的部分回應"""  
         with patch("requests.get") as mock_get:
             mock_response = Mock()
+            mock_response.status_code = 200
             mock_response.json.side_effect = ValueError("Expecting property name enclosed in double quotes")
             mock_response.text = '{"data": {"price": 150.0, "volume":'
             mock_get.return_value = mock_response
@@ -157,4 +166,4 @@ class TestBaseRest:
             with pytest.raises(Exception) as exc_info:
                 base_rest_with_api_key.request("/stock/quote/2330")
             
-            assert "An unexpected data error occurred.\nPlease try again later. If the issue persists, please contact support at  (tech.support@fugle.tw)" in str(exc_info.value)
+            assert "Failed to parse JSON response" in str(exc_info.value)

--- a/tests/test_fugle_realtime.py
+++ b/tests/test_fugle_realtime.py
@@ -1,5 +1,10 @@
+import re
+
 from fugle_marketdata import __version__
 
 
 def test_version():
-    assert __version__ == '0.1.0'
+    # The package version is bumped on every release, so assert it is a
+    # well-formed semantic version rather than pinning a specific number.
+    assert isinstance(__version__, str)
+    assert re.match(r'^\d+\.\d+\.\d+', __version__)

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -17,6 +17,14 @@ def bearer_client():
 def custom_base_url_client():
     return RestClient(api_key='test-key', base_url='https://custom-api.example.com/v2.0')
 
+def _configure_get(mock_get):
+    """Give a patched ``requests.get`` a successful, JSON-parsable response so
+    BaseRest.request()'s ``response.status_code >= 400`` check doesn't choke on
+    a bare MagicMock. Returns the same mock for call-argument assertions."""
+    mock_get.return_value.status_code = 200
+    mock_get.return_value.json.return_value = {}
+    return mock_get
+
 class TestRestClientConstructor(object):
     def test_with_apiKey(self):
         # 建立 RestClient 實例並測試是否為 RestClient 物件
@@ -78,7 +86,7 @@ class TestStockRestIntradayClient:
 
     def test_intraday_tickers_api_key(self, mocker, api_key_client):
         stock = api_key_client.stock
-        mock_get = mocker.patch('requests.get')
+        mock_get = _configure_get(mocker.patch('requests.get'))
         stock.intraday.tickers(type='INDEX')
         mock_get.assert_called_once_with(
             'https://api.fugle.tw/marketdata/v1.0/stock/intraday/tickers?type=INDEX',
@@ -87,7 +95,7 @@ class TestStockRestIntradayClient:
 
     def test_intraday_tickers_bearer_token(self, bearer_client, mocker):
         stock = bearer_client.stock
-        mock_get = mocker.patch('requests.get')
+        mock_get = _configure_get(mocker.patch('requests.get'))
         stock.intraday.tickers(type='INDEX')
         mock_get.assert_called_once_with(
             'https://api.fugle.tw/marketdata/v1.0/stock/intraday/tickers?type=INDEX',
@@ -96,7 +104,7 @@ class TestStockRestIntradayClient:
 
     def test_intraday_ticker_api_key(self, mocker, api_key_client):
         stock = api_key_client.stock
-        mock_get = mocker.patch('requests.get')
+        mock_get = _configure_get(mocker.patch('requests.get'))
         stock.intraday.ticker(symbol='2330')
         mock_get.assert_called_once_with(
             'https://api.fugle.tw/marketdata/v1.0/stock/intraday/ticker/2330',
@@ -105,7 +113,7 @@ class TestStockRestIntradayClient:
 
     def test_intraday_ticker_bearer_token(self, bearer_client, mocker):
         stock = bearer_client.stock
-        mock_get = mocker.patch('requests.get')
+        mock_get = _configure_get(mocker.patch('requests.get'))
         stock.intraday.ticker(symbol='2330')
         mock_get.assert_called_once_with(
             'https://api.fugle.tw/marketdata/v1.0/stock/intraday/ticker/2330',
@@ -115,7 +123,7 @@ class TestStockRestIntradayClient:
 
     def test_intraday_quote_api_key(self, mocker, api_key_client):
         stock = api_key_client.stock
-        mock_get = mocker.patch('requests.get')
+        mock_get = _configure_get(mocker.patch('requests.get'))
         stock.intraday.quote(symbol='2330')
         mock_get.assert_called_once_with(
             'https://api.fugle.tw/marketdata/v1.0/stock/intraday/quote/2330',
@@ -124,7 +132,7 @@ class TestStockRestIntradayClient:
 
     def test_intraday_quote_bearer_token(self, bearer_client, mocker):
         stock = bearer_client.stock
-        mock_get = mocker.patch('requests.get')
+        mock_get = _configure_get(mocker.patch('requests.get'))
         stock.intraday.quote(symbol='2330')
         mock_get.assert_called_once_with(
             'https://api.fugle.tw/marketdata/v1.0/stock/intraday/quote/2330',
@@ -133,7 +141,7 @@ class TestStockRestIntradayClient:
 
     def test_intraday_trades_api_key(self, mocker, api_key_client):
         stock = api_key_client.stock
-        mock_get = mocker.patch('requests.get')
+        mock_get = _configure_get(mocker.patch('requests.get'))
         stock.intraday.trades(symbol='2330')
         mock_get.assert_called_once_with(
             'https://api.fugle.tw/marketdata/v1.0/stock/intraday/trades/2330',
@@ -142,7 +150,7 @@ class TestStockRestIntradayClient:
 
     def test_intraday_trades_bearer_token(self, bearer_client, mocker):
         stock = bearer_client.stock
-        mock_get = mocker.patch('requests.get')
+        mock_get = _configure_get(mocker.patch('requests.get'))
         stock.intraday.trades(symbol='2330')
         mock_get.assert_called_once_with(
             'https://api.fugle.tw/marketdata/v1.0/stock/intraday/trades/2330',
@@ -151,7 +159,7 @@ class TestStockRestIntradayClient:
 
     def test_intraday_volumes_api_key(self, mocker, api_key_client):
         stock = api_key_client.stock
-        mock_get = mocker.patch('requests.get')
+        mock_get = _configure_get(mocker.patch('requests.get'))
         stock.intraday.volumes(symbol='2330')
         mock_get.assert_called_once_with(
             'https://api.fugle.tw/marketdata/v1.0/stock/intraday/volumes/2330',
@@ -160,7 +168,7 @@ class TestStockRestIntradayClient:
 
     def test_intraday_volumes_bearer_token(self, bearer_client, mocker):
         stock = bearer_client.stock
-        mock_get = mocker.patch('requests.get')
+        mock_get = _configure_get(mocker.patch('requests.get'))
         stock.intraday.volumes(symbol='2330')
         mock_get.assert_called_once_with(
             'https://api.fugle.tw/marketdata/v1.0/stock/intraday/volumes/2330',
@@ -169,7 +177,7 @@ class TestStockRestIntradayClient:
 
     def test_intraday_quote_custom_base_url(self, mocker, custom_base_url_client):
         stock = custom_base_url_client.stock
-        mock_get = mocker.patch('requests.get')
+        mock_get = _configure_get(mocker.patch('requests.get'))
         stock.intraday.quote(symbol='2330')
         mock_get.assert_called_once_with(
             'https://custom-api.example.com/v2.0/stock/intraday/quote/2330',
@@ -184,7 +192,7 @@ class TestStockRestHistoricalClient:
 
     def test_historical_candles_api_key(self, mocker, api_key_client):
         stock = api_key_client.stock
-        mock_get = mocker.patch('requests.get')
+        mock_get = _configure_get(mocker.patch('requests.get'))
         stock.historical.candles(symbol='2330')
         mock_get.assert_called_once_with(
             'https://api.fugle.tw/marketdata/v1.0/stock/historical/candles/2330',
@@ -193,7 +201,7 @@ class TestStockRestHistoricalClient:
 
     def test_historical_candles_bearer_token(self, bearer_client, mocker):
         stock = bearer_client.stock
-        mock_get = mocker.patch('requests.get')
+        mock_get = _configure_get(mocker.patch('requests.get'))
         stock.historical.candles(symbol='2330')
         mock_get.assert_called_once_with(
             'https://api.fugle.tw/marketdata/v1.0/stock/historical/candles/2330',
@@ -202,7 +210,7 @@ class TestStockRestHistoricalClient:
 
     def test_historical_stats_api_key(self, mocker, api_key_client):
         stock = api_key_client.stock
-        mock_get = mocker.patch('requests.get')
+        mock_get = _configure_get(mocker.patch('requests.get'))
         stock.historical.stats(symbol='2330')
         mock_get.assert_called_once_with(
             'https://api.fugle.tw/marketdata/v1.0/stock/historical/stats/2330',
@@ -211,7 +219,7 @@ class TestStockRestHistoricalClient:
 
     def test_historical_stats_bearer_token(self, bearer_client, mocker):
         stock = bearer_client.stock
-        mock_get = mocker.patch('requests.get')
+        mock_get = _configure_get(mocker.patch('requests.get'))
         stock.historical.stats(symbol='2330')
         mock_get.assert_called_once_with(
             'https://api.fugle.tw/marketdata/v1.0/stock/historical/stats/2330',
@@ -227,7 +235,7 @@ class TestStockRestSnapshotClient:
 
     def test_snapshot_quotes_api_key(self, mocker, api_key_client):
         stock = api_key_client.stock
-        mock_get = mocker.patch('requests.get')
+        mock_get = _configure_get(mocker.patch('requests.get'))
         stock.snapshot.quotes(market='TSE')
         mock_get.assert_called_once_with(
             'https://api.fugle.tw/marketdata/v1.0/stock/snapshot/quotes/TSE',
@@ -236,7 +244,7 @@ class TestStockRestSnapshotClient:
 
     def test_snapshot_quotes_bearer_token(self, bearer_client, mocker):
         stock = bearer_client.stock
-        mock_get = mocker.patch('requests.get')
+        mock_get = _configure_get(mocker.patch('requests.get'))
         stock.snapshot.quotes(market='TSE')
         mock_get.assert_called_once_with(
             'https://api.fugle.tw/marketdata/v1.0/stock/snapshot/quotes/TSE',
@@ -245,7 +253,7 @@ class TestStockRestSnapshotClient:
 
     def test_snapshot_movers_api_key(self, mocker, api_key_client):
         stock = api_key_client.stock
-        mock_get = mocker.patch('requests.get')
+        mock_get = _configure_get(mocker.patch('requests.get'))
         stock.snapshot.movers(market='TSE', change='percent', direction='up')
         mock_get.assert_called_once_with(
             'https://api.fugle.tw/marketdata/v1.0/stock/snapshot/movers/TSE?change=percent&direction=up',
@@ -254,7 +262,7 @@ class TestStockRestSnapshotClient:
 
     def test_snapshot_movers_bearer_token(self, bearer_client, mocker):
         stock = bearer_client.stock
-        mock_get = mocker.patch('requests.get')
+        mock_get = _configure_get(mocker.patch('requests.get'))
         stock.snapshot.movers(market='TSE', change='percent', direction='up')
         mock_get.assert_called_once_with(
             'https://api.fugle.tw/marketdata/v1.0/stock/snapshot/movers/TSE?change=percent&direction=up',
@@ -263,7 +271,7 @@ class TestStockRestSnapshotClient:
 
     def test_snapshot_actives_api_key(self, mocker, api_key_client):
         stock = api_key_client.stock
-        mock_get = mocker.patch('requests.get')
+        mock_get = _configure_get(mocker.patch('requests.get'))
         stock.snapshot.actives(market='TSE', trade='volume')
         mock_get.assert_called_once_with(
             'https://api.fugle.tw/marketdata/v1.0/stock/snapshot/actives/TSE?trade=volume',
@@ -272,7 +280,7 @@ class TestStockRestSnapshotClient:
 
     def test_snapshot_actives_bearer_token(self, bearer_client, mocker):
         stock = bearer_client.stock
-        mock_get = mocker.patch('requests.get')
+        mock_get = _configure_get(mocker.patch('requests.get'))
         stock.snapshot.actives(market='TSE', trade='volume')
         mock_get.assert_called_once_with(
             'https://api.fugle.tw/marketdata/v1.0/stock/snapshot/actives/TSE?trade=volume',
@@ -292,7 +300,7 @@ class TestFutOptRestIntradayClient:
 
     def test_intraday_products_api_key(self, mocker, api_key_client):
         futopt = api_key_client.futopt
-        mock_get = mocker.patch('requests.get')
+        mock_get = _configure_get(mocker.patch('requests.get'))
         futopt.intraday.products(type='OPTION')
         mock_get.assert_called_once_with(
             'https://api.fugle.tw/marketdata/v1.0/futopt/intraday/products?type=OPTION',
@@ -301,16 +309,27 @@ class TestFutOptRestIntradayClient:
 
     def test_intraday_tickers_api_key(self, mocker, api_key_client):
         futopt = api_key_client.futopt
-        mock_get = mocker.patch('requests.get')
+        mock_get = _configure_get(mocker.patch('requests.get'))
         futopt.intraday.tickers(type='OPTION')
         mock_get.assert_called_once_with(
             'https://api.fugle.tw/marketdata/v1.0/futopt/intraday/tickers?type=OPTION',
             headers={'X-API-KEY': 'api-key'}
         )
-    
+
+    def test_intraday_tickers_is_spread(self, mocker, api_key_client):
+        futopt = api_key_client.futopt
+        mock_get = _configure_get(mocker.patch('requests.get'))
+        # NOTE: pass the string 'true'/'false' (not a Python bool) so the
+        # backend boolean transform recognises the value.
+        futopt.intraday.tickers(type='FUTURE', isSpread='true')
+        mock_get.assert_called_once_with(
+            'https://api.fugle.tw/marketdata/v1.0/futopt/intraday/tickers?type=FUTURE&isSpread=true',
+            headers={'X-API-KEY': 'api-key'}
+        )
+
     def test_intraday_ticker_api_key(self, mocker, api_key_client):
         futopt = api_key_client.futopt
-        mock_get = mocker.patch('requests.get')
+        mock_get = _configure_get(mocker.patch('requests.get'))
         futopt.intraday.ticker(symbol='2330')
         mock_get.assert_called_once_with(
             'https://api.fugle.tw/marketdata/v1.0/futopt/intraday/ticker/2330',
@@ -319,16 +338,25 @@ class TestFutOptRestIntradayClient:
 
     def test_intraday_quote_api_key(self, mocker, api_key_client):
         futopt = api_key_client.futopt
-        mock_get = mocker.patch('requests.get')
+        mock_get = _configure_get(mocker.patch('requests.get'))
         futopt.intraday.quote(symbol='2330')
         mock_get.assert_called_once_with(
             'https://api.fugle.tw/marketdata/v1.0/futopt/intraday/quote/2330',
             headers={'X-API-KEY': 'api-key'}
         )
 
+    def test_intraday_quote_spread_symbol(self, mocker, api_key_client):
+        futopt = api_key_client.futopt
+        mock_get = _configure_get(mocker.patch('requests.get'))
+        futopt.intraday.quote(symbol='MXFA6/C6')
+        mock_get.assert_called_once_with(
+            'https://api.fugle.tw/marketdata/v1.0/futopt/intraday/quote/MXFA6%2FC6',
+            headers={'X-API-KEY': 'api-key'}
+        )
+
     def test_intraday_candles_api_key(self, mocker, api_key_client):
         futopt = api_key_client.futopt
-        mock_get = mocker.patch('requests.get')
+        mock_get = _configure_get(mocker.patch('requests.get'))
         futopt.intraday.candles(symbol='2330')
         mock_get.assert_called_once_with(
             'https://api.fugle.tw/marketdata/v1.0/futopt/intraday/candles/2330',
@@ -337,16 +365,25 @@ class TestFutOptRestIntradayClient:
 
     def test_intraday_trades_api_key(self, mocker, api_key_client):
         futopt = api_key_client.futopt
-        mock_get = mocker.patch('requests.get')
+        mock_get = _configure_get(mocker.patch('requests.get'))
         futopt.intraday.trades(symbol='2330')
         mock_get.assert_called_once_with(
             'https://api.fugle.tw/marketdata/v1.0/futopt/intraday/trades/2330',
             headers={'X-API-KEY': 'api-key'}
         )
 
+    def test_intraday_trades_is_trial(self, mocker, api_key_client):
+        futopt = api_key_client.futopt
+        mock_get = _configure_get(mocker.patch('requests.get'))
+        futopt.intraday.trades(symbol='TXFA6', isTrial='true')
+        mock_get.assert_called_once_with(
+            'https://api.fugle.tw/marketdata/v1.0/futopt/intraday/trades/TXFA6?isTrial=true',
+            headers={'X-API-KEY': 'api-key'}
+        )
+
     def test_intraday_volumes_api_key(self, mocker, api_key_client):
         futopt = api_key_client.futopt
-        mock_get = mocker.patch('requests.get')
+        mock_get = _configure_get(mocker.patch('requests.get'))
         futopt.intraday.volumes(symbol='2330')
         mock_get.assert_called_once_with(
             'https://api.fugle.tw/marketdata/v1.0/futopt/intraday/volumes/2330',
@@ -361,7 +398,7 @@ class TestFutOptRestHistoricalClient:
 
     def test_historical_candles_api_key(self, mocker, api_key_client):
         futopt = api_key_client.futopt
-        mock_get = mocker.patch('requests.get')
+        mock_get = _configure_get(mocker.patch('requests.get'))
         futopt.historical.candles(symbol='2330')
         mock_get.assert_called_once_with(
             'https://api.fugle.tw/marketdata/v1.0/futopt/historical/candles/2330',
@@ -370,7 +407,7 @@ class TestFutOptRestHistoricalClient:
 
     def test_historical_candles_bearer_token(self, bearer_client, mocker):
         futopt = bearer_client.futopt
-        mock_get = mocker.patch('requests.get')
+        mock_get = _configure_get(mocker.patch('requests.get'))
         futopt.historical.candles(symbol='2330')
         mock_get.assert_called_once_with(
             'https://api.fugle.tw/marketdata/v1.0/futopt/historical/candles/2330',
@@ -379,7 +416,7 @@ class TestFutOptRestHistoricalClient:
 
     def test_historical_daily_api_key(self, mocker, api_key_client):
         futopt = api_key_client.futopt
-        mock_get = mocker.patch('requests.get')
+        mock_get = _configure_get(mocker.patch('requests.get'))
         futopt.historical.daily(symbol='2330')
         mock_get.assert_called_once_with(
             'https://api.fugle.tw/marketdata/v1.0/futopt/historical/daily/2330',
@@ -388,7 +425,7 @@ class TestFutOptRestHistoricalClient:
 
     def test_historical_daily_bearer_token(self, bearer_client, mocker):
         futopt = bearer_client.futopt
-        mock_get = mocker.patch('requests.get')
+        mock_get = _configure_get(mocker.patch('requests.get'))
         futopt.historical.daily(symbol='2330')
         mock_get.assert_called_once_with(
             'https://api.fugle.tw/marketdata/v1.0/futopt/historical/daily/2330',
@@ -407,7 +444,7 @@ class TestStockRestTechnicalClient:
 
     def test_technical_sma_api_key(self, mocker, api_key_client):
         stock = api_key_client.stock
-        mock_get = mocker.patch('requests.get')
+        mock_get = _configure_get(mocker.patch('requests.get'))
         stock.technical.sma(symbol='2330')
         mock_get.assert_called_once_with(
             'https://api.fugle.tw/marketdata/v1.0/stock/technical/sma/2330',
@@ -416,7 +453,7 @@ class TestStockRestTechnicalClient:
 
     def test_technical_sma_bearer_token(self, mocker, bearer_client):
         stock = bearer_client.stock
-        mock_get = mocker.patch('requests.get')
+        mock_get = _configure_get(mocker.patch('requests.get'))
         stock.technical.sma(symbol='2330')
         mock_get.assert_called_once_with(
             'https://api.fugle.tw/marketdata/v1.0/stock/technical/sma/2330',
@@ -425,7 +462,7 @@ class TestStockRestTechnicalClient:
 
     def test_technical_rsi_api_key(self, mocker, api_key_client):
         stock = api_key_client.stock
-        mock_get = mocker.patch('requests.get')
+        mock_get = _configure_get(mocker.patch('requests.get'))
         stock.technical.rsi(symbol='2330')
         mock_get.assert_called_once_with(
             'https://api.fugle.tw/marketdata/v1.0/stock/technical/rsi/2330',
@@ -434,7 +471,7 @@ class TestStockRestTechnicalClient:
 
     def test_technical_rsi_bearer_token(self, mocker, bearer_client):
         stock = bearer_client.stock
-        mock_get = mocker.patch('requests.get')
+        mock_get = _configure_get(mocker.patch('requests.get'))
         stock.technical.rsi(symbol='2330')
         mock_get.assert_called_once_with(
             'https://api.fugle.tw/marketdata/v1.0/stock/technical/rsi/2330',
@@ -443,7 +480,7 @@ class TestStockRestTechnicalClient:
 
     def test_technical_kdj_api_key(self, mocker, api_key_client):
         stock = api_key_client.stock
-        mock_get = mocker.patch('requests.get')
+        mock_get = _configure_get(mocker.patch('requests.get'))
         stock.technical.kdj(symbol='2330')
         mock_get.assert_called_once_with(
             'https://api.fugle.tw/marketdata/v1.0/stock/technical/kdj/2330',
@@ -452,7 +489,7 @@ class TestStockRestTechnicalClient:
 
     def test_technical_kdj_bearer_token(self, mocker, bearer_client):
         stock = bearer_client.stock
-        mock_get = mocker.patch('requests.get')
+        mock_get = _configure_get(mocker.patch('requests.get'))
         stock.technical.kdj(symbol='2330')
         mock_get.assert_called_once_with(
             'https://api.fugle.tw/marketdata/v1.0/stock/technical/kdj/2330',
@@ -461,7 +498,7 @@ class TestStockRestTechnicalClient:
 
     def test_technical_macd_api_key(self, mocker, api_key_client):
         stock = api_key_client.stock
-        mock_get = mocker.patch('requests.get')
+        mock_get = _configure_get(mocker.patch('requests.get'))
         stock.technical.macd(symbol='2330')
         mock_get.assert_called_once_with(
             'https://api.fugle.tw/marketdata/v1.0/stock/technical/macd/2330',
@@ -470,7 +507,7 @@ class TestStockRestTechnicalClient:
 
     def test_technical_macd_bearer_token(self, mocker, bearer_client):
         stock = bearer_client.stock
-        mock_get = mocker.patch('requests.get')
+        mock_get = _configure_get(mocker.patch('requests.get'))
         stock.technical.macd(symbol='2330')
         mock_get.assert_called_once_with(
             'https://api.fugle.tw/marketdata/v1.0/stock/technical/macd/2330',
@@ -479,7 +516,7 @@ class TestStockRestTechnicalClient:
 
     def test_technical_bb_api_key(self, mocker, api_key_client):
         stock = api_key_client.stock
-        mock_get = mocker.patch('requests.get')
+        mock_get = _configure_get(mocker.patch('requests.get'))
         stock.technical.bb(symbol='2330')
         mock_get.assert_called_once_with(
             'https://api.fugle.tw/marketdata/v1.0/stock/technical/bb/2330',
@@ -488,7 +525,7 @@ class TestStockRestTechnicalClient:
 
     def test_technical_bb_bearer_token(self, mocker, bearer_client):
         stock = bearer_client.stock
-        mock_get = mocker.patch('requests.get')
+        mock_get = _configure_get(mocker.patch('requests.get'))
         stock.technical.bb(symbol='2330')
         mock_get.assert_called_once_with(
             'https://api.fugle.tw/marketdata/v1.0/stock/technical/bb/2330',
@@ -555,7 +592,7 @@ class TestRestClientRegressionTests:
     def test_existing_api_endpoints_still_work(self, mocker, api_key_client):
         # 回歸測試：確保現有的 API 端點仍然正常工作
         stock = api_key_client.stock
-        mock_get = mocker.patch('requests.get')
+        mock_get = _configure_get(mocker.patch('requests.get'))
         
         # 測試幾個主要的 API 端點
         stock.intraday.quote(symbol='2330')


### PR DESCRIPTION
Aligns the SDK with fugle-realtime backend issues #607 / #608 / #609.

## Changes
- **#607 spread contracts (複式商品)**: URL-encode futopt symbols so codes containing `/` (e.g. `MXFA6/C6`) route correctly. This is the only required code change — the client returns raw JSON, so new response fields flow through automatically. Note: pass `isSpread="true"` as a **string** (backend expects a lowercase string).
- **#609 trial matching (試搓)**: `lastTrial`/`isTrial` quote fields and `intraday.trades(isTrial=...)` for trial ticks flow through automatically; documented in README.
- **#608 derived 6th order-book level**: `derivedBid`/`derivedAsk` pass through raw WebSocket `books` messages — documented, no code change.

## Commits
1. `test:` repair pre-existing broken suite (stale `base_rest` error assertions + `0.1.0` version pin) — unrelated to the issues, split out separately.
2. `feat:` url-encode futopt symbols + trial docs/tests.

`pytest` green (105 passed).

Backend issues (fugle-realtime):
- https://git.fugle.tw/fugle/workspace-devs/fugle-realtime/-/issues/607
- https://git.fugle.tw/fugle/workspace-devs/fugle-realtime/-/issues/608
- https://git.fugle.tw/fugle/workspace-devs/fugle-realtime/-/issues/609

🤖 Generated with [Claude Code](https://claude.com/claude-code)