### PR TITLE
refactor(etf): remove code query param from etf-holdings

### DIFF
--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -247,9 +247,9 @@ class TestStockRestOwnershipClient:
         stock = api_key_client.stock
         mock_get = mocker.patch('requests.get')
         mock_get.return_value.status_code = 200
-        stock.ownership.etf_holdings(symbol='0050', **{'from': '2026-05-01'}, to='2026-05-21', sort='desc', code='2330')
+        stock.ownership.etf_holdings(symbol='0050', **{'from': '2026-05-01'}, to='2026-05-21', sort='desc')
         mock_get.assert_called_once_with(
-            'https://api.fugle.tw/marketdata/v1.0/stock/ownership/etf-holdings/0050?from=2026-05-01&to=2026-05-21&sort=desc&code=2330',
+            'https://api.fugle.tw/marketdata/v1.0/stock/ownership/etf-holdings/0050?from=2026-05-01&to=2026-05-21&sort=desc',
             headers={'X-API-KEY': 'api-key'}
         )
 


### PR DESCRIPTION
## 概要
對齊 server-side MR [!376](https://git.fugle.tw/fugle/workspace-devs/fugle-realtime/-/merge_requests/376)，移除 `GET /v1.0/stock/ownership/etf-holdings/:symbol` 的選填 `code` query param。

這是 #19（新增 ETF endpoint）的 follow-up。#19 已 merge 進 `release/v2.5.0` 但尚未 release，趁 release 前把 `code` 拿掉，使用者不會看到帶 `code` 的版本。

## 為什麼移除
Server MR !376 已移除該 param（命名不一致、功能雞肋、cache key 膨脹）。移除後仍是 **soft degrade**：server 未開 whitelist，舊呼叫帶 `?code=` 不會報錯，只是拿回未過濾的完整清單。需過濾單一成分股時，client 端一行 filter `components` 即可。

## 變更內容
- 實作用 `**params` 純轉發，**無需更動**
- `tests/test_http_client.py`：測試移除 `code`，URL 斷言同步更新

## 測試
- `pytest -k etf_holdings`：3 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)