### PR TITLE
fix(client)!: separate base_url from the API version

### DIFF
--- a/fugle_marketdata/base_url.py
+++ b/fugle_marketdata/base_url.py
@@ -1,0 +1,26 @@
+import re
+
+_VERSION_SEGMENT = re.compile(r'/v\d+\.\d+$')
+
+
+def with_version(base_url, version, hint=''):
+    """Join a caller-supplied `base_url` with the version the SDK resolved.
+
+    `base_url` carries the host and path prefix and nothing else; the version
+    segment is always appended here. A version written into `base_url` is
+    rejected rather than swapped or appended on top of, because letting two
+    options decide the same path segment is what forced the old precedence
+    rules — and those rules meant anyone who only wanted to change host was
+    made to manage the version by hand.
+    """
+    trimmed = base_url.rstrip('/')
+    existing = _VERSION_SEGMENT.search(trimmed)
+
+    if existing:
+        raise TypeError(
+            f"base_url must not include a version segment (found '{existing.group()}'). "
+            f"Pass the host and path prefix only: '{trimmed[:existing.start()]}'."
+            + (f' {hint}' if hint else '')
+        )
+
+    return f'{trimmed}/{version}'

--- a/fugle_marketdata/rest/factory.py
+++ b/fugle_marketdata/rest/factory.py
@@ -1,3 +1,4 @@
+from ..base_url import with_version
 from ..client_factory import ClientFactory
 from ..constants import FUGLE_MARKETDATA_API_REST_BASE_URL, FUGLE_MARKETDATA_API_VERSION
 from .stock import RestStockClient
@@ -19,11 +20,16 @@ class RestClientFactory(ClientFactory):
         return self.get_client('futopt')
 
     def get_client(self, type):
-        base_url = self.options.get('base_url')
-        if not base_url:
-            base_url = f"{FUGLE_MARKETDATA_API_REST_BASE_URL}/{FUGLE_MARKETDATA_API_VERSION}"
+        # Same rule as streaming: base_url is host and path prefix, the SDK owns
+        # the version segment. REST serves one version, so there's no option to
+        # choose it with — but a version written into base_url is still rejected
+        # rather than silently doubled.
+        base_url = with_version(
+            self.options.get('base_url') or FUGLE_MARKETDATA_API_REST_BASE_URL,
+            FUGLE_MARKETDATA_API_VERSION,
+        )
 
-        url = f'{base_url.rstrip("/")}/{type}'
+        url = f'{base_url}/{type}'
 
         if type in self.__clients:
             return self.__clients[type]

--- a/fugle_marketdata/websocket/factory.py
+++ b/fugle_marketdata/websocket/factory.py
@@ -1,7 +1,8 @@
+from ..base_url import with_version
 from ..client_factory import ClientFactory
 from .futopt import WebSocketFutOptClient
 from .stock import WebSocketStockClient
-from .version import apply_version_to_base_url, resolve_version
+from .version import VERSION_OPTION_HINT, resolve_version
 from ..constants import FUGLE_MARKETDATA_API_WEBSOCKET_BASE_URL
 
 class WebSocketClientFactory(ClientFactory):
@@ -19,28 +20,21 @@ class WebSocketClientFactory(ClientFactory):
         return self.get_client('futopt')
 
     def __resolve_base_url(self, type):
-        """A base_url is only re-versioned when `version` was explicitly
-        supplied. Left alone otherwise, the version the caller wrote into their
-        URL wins — which keeps custom and internal deployments (whose paths need
-        not follow the public versioning at all) working exactly as before.
+        """`base_url` picks the host and path prefix; `version` picks the
+        version. Nothing else: a custom endpoint is written the same way as the
+        public one, and pointing at a different host never forces the caller to
+        track versions by hand.
         """
         version = resolve_version(type, self.options.get('version'))
-        base_url = self.options.get('base_url')
-
-        if not base_url:
-            return f"{FUGLE_MARKETDATA_API_WEBSOCKET_BASE_URL}/{version}"
-
-        if self.options.get('version') is None:
-            return base_url
-
-        return apply_version_to_base_url(base_url, version)
+        base_url = self.options.get('base_url') or FUGLE_MARKETDATA_API_WEBSOCKET_BASE_URL
+        return with_version(base_url, version, VERSION_OPTION_HINT)
 
     def get_client(self, type):
         if type in self.__clients:
             return self.__clients[type]
 
         base_url = self.__resolve_base_url(type)
-        url = f'{base_url.rstrip("/")}/{type}/streaming'
+        url = f'{base_url}/{type}/streaming'
 
         client_options = {**self.options, 'base_url': url}
 

--- a/fugle_marketdata/websocket/version.py
+++ b/fugle_marketdata/websocket/version.py
@@ -1,6 +1,9 @@
-import re
-
 from ..constants import FUGLE_MARKETDATA_WS_SUPPORTED_VERSIONS
+
+#: Appended to `base_url` rejections, pointing at the option that owns the version.
+VERSION_OPTION_HINT = (
+    "The version comes from the `version` option, e.g. version={'futopt': 'v1.1'}."
+)
 
 
 def supported_versions(product):
@@ -30,22 +33,34 @@ def _assert_supported(product, version, hint):
 def resolve_version(product, version=None):
     """Resolve the streaming version for a product from the `version` option.
 
-    Omitted entirely, or omitted for this product in the mapping form, means the
-    product's latest. Nothing is ever silently clamped: asking for a version a
-    product doesn't serve raises rather than quietly handing back an older one.
+    Omitted entirely, an empty mapping, or omitted for this product all mean the
+    same thing: that product's latest. Nothing is ever silently clamped — asking
+    for a version a product doesn't serve raises rather than quietly handing back
+    an older one.
+
+    A bare version string used to be accepted as "this version for every
+    product", but which product it applied to wasn't known until a client was
+    taken off the factory, so an unsupported pairing only surfaced then — and
+    with the products serving different version sets, the only scalar that never
+    raises is the one every product happens to share. The mapping form says the
+    same thing without the trap.
     """
     if version is None:
         return latest_version(product)
 
     if isinstance(version, str):
         alternatives = _products_supporting(version)
-        hint = (
-            f"Use version={{'{alternatives[0]}': '{version}'}} to target a single product."
+        suggestion = (
+            'Use version={'
+            + ', '.join(f"'{p}': '{version}'" for p in alternatives)
+            + '}.'
             if alternatives
-            else f"No product serves {version}."
+            else f'No product serves {version}.'
         )
-        _assert_supported(product, version, hint)
-        return version
+        raise TypeError(
+            f"version must be a per-product mapping, not the bare string "
+            f"'{version}'. {suggestion}"
+        )
 
     requested = version.get(product)
     if requested is None:
@@ -57,18 +72,3 @@ def resolve_version(product, version=None):
         f"Remove it from the version mapping to use {latest_version(product)}.",
     )
     return requested
-
-
-_VERSION_SEGMENT = re.compile(r'/v\d+\.\d+$')
-
-
-def apply_version_to_base_url(base_url, version):
-    """Point an explicitly supplied `base_url` at `version` by swapping its
-    trailing version segment (`.../marketdata/v1.0` -> `.../marketdata/v1.1`).
-
-    A base_url without a recognizable version segment is left alone — it may be
-    a proxy or an internal deployment that doesn't encode a version in its path,
-    and inventing one would break it.
-    """
-    trimmed = base_url.rstrip('/')
-    return _VERSION_SEGMENT.sub(f'/{version}', trimmed)

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -15,7 +15,7 @@ def bearer_client():
 
 @pytest.fixture
 def custom_base_url_client():
-    return RestClient(api_key='test-key', base_url='https://custom-api.example.com/v2.0')
+    return RestClient(api_key='test-key', base_url='https://custom-api.example.com')
 
 def _configure_get(mock_get):
     """Give a patched ``requests.get`` a successful, JSON-parsable response so
@@ -48,9 +48,9 @@ class TestRestClientConstructor(object):
 
     def test_with_custom_base_url(self):
         # 測試自訂 base_url 是否正確設定
-        client = RestClient(api_key='api-key', base_url='https://custom-api.example.com/v2.0')
+        client = RestClient(api_key='api-key', base_url='https://custom-api.example.com')
         assert isinstance(client, RestClient)
-        assert client.options['base_url'] == 'https://custom-api.example.com/v2.0'
+        assert client.options['base_url'] == 'https://custom-api.example.com'
 
 
 
@@ -67,7 +67,7 @@ class TestStockRestClient:
     def test_stock_with_custom_base_url(self, custom_base_url_client):
         stock = custom_base_url_client.stock
         assert isinstance(stock, RestStockClient)
-        assert stock.config['base_url'] == 'https://custom-api.example.com/v2.0/stock'
+        assert stock.config['base_url'] == 'https://custom-api.example.com/v1.0/stock'
 
     def test_stock_and_futopt_different_instances(self, api_key_client):
         stock = api_key_client.stock
@@ -180,7 +180,7 @@ class TestStockRestIntradayClient:
         mock_get = _configure_get(mocker.patch('requests.get'))
         stock.intraday.quote(symbol='2330')
         mock_get.assert_called_once_with(
-            'https://custom-api.example.com/v2.0/stock/intraday/quote/2330',
+            'https://custom-api.example.com/v1.0/stock/intraday/quote/2330',
             headers={'X-API-KEY': 'test-key'}
         )
 
@@ -581,16 +581,16 @@ class TestRestClientFactoryUrlConstruction:
     def test_custom_base_url_construction(self, custom_base_url_client):
         # 測試自訂 base_url 的 URL 構造
         stock = custom_base_url_client.stock
-        assert stock.config['base_url'] == 'https://custom-api.example.com/v2.0/stock'
+        assert stock.config['base_url'] == 'https://custom-api.example.com/v1.0/stock'
         
         futopt = custom_base_url_client.futopt
-        assert futopt.config['base_url'] == 'https://custom-api.example.com/v2.0/futopt'
+        assert futopt.config['base_url'] == 'https://custom-api.example.com/v1.0/futopt'
 
     def test_url_construction_with_trailing_slash(self):
         # 測試帶有結尾斜線的 base_url，確保沒有雙斜線
-        client = RestClient(api_key='test-key', base_url='https://api.example.com/v1/')
+        client = RestClient(api_key='test-key', base_url='https://api.example.com/marketdata/')
         stock = client.stock
-        assert stock.config['base_url'] == 'https://api.example.com/v1/stock'
+        assert stock.config['base_url'] == 'https://api.example.com/marketdata/v1.0/stock'
 
     def test_multiple_clients_independent_base_urls(self):
         # 測試多個客戶端的 base_url 是獨立的
@@ -600,8 +600,8 @@ class TestRestClientFactoryUrlConstruction:
         stock1 = client1.stock
         stock2 = client2.stock
         
-        assert stock1.config['base_url'] == 'https://api1.example.com/stock'
-        assert stock2.config['base_url'] == 'https://api2.example.com/stock'
+        assert stock1.config['base_url'] == 'https://api1.example.com/v1.0/stock'
+        assert stock2.config['base_url'] == 'https://api2.example.com/v1.0/stock'
 
 
 class TestRestClientRegressionTests:
@@ -646,26 +646,26 @@ class TestRestClientRegressionTests:
 class TestRestClientUrlNormalization:
     def test_no_trailing_slash_base_url(self):
         # 測試沒有結尾斜線的 base_url
-        client = RestClient(api_key='test-key', base_url='https://api.example.com/v1')
+        client = RestClient(api_key='test-key', base_url='https://api.example.com/marketdata')
         stock = client.stock
-        assert stock.config['base_url'] == 'https://api.example.com/v1/stock'
+        assert stock.config['base_url'] == 'https://api.example.com/marketdata/v1.0/stock'
         
     def test_single_trailing_slash_base_url(self):
         # 測試單一結尾斜線的 base_url
-        client = RestClient(api_key='test-key', base_url='https://api.example.com/v1/')
+        client = RestClient(api_key='test-key', base_url='https://api.example.com/marketdata/')
         stock = client.stock
-        assert stock.config['base_url'] == 'https://api.example.com/v1/stock'
+        assert stock.config['base_url'] == 'https://api.example.com/marketdata/v1.0/stock'
         
     def test_multiple_trailing_slashes_base_url(self):
         # 測試多個結尾斜線的 base_url
-        client = RestClient(api_key='test-key', base_url='https://api.example.com/v1///')
+        client = RestClient(api_key='test-key', base_url='https://api.example.com/marketdata///')
         stock = client.stock
-        assert stock.config['base_url'] == 'https://api.example.com/v1/stock'
+        assert stock.config['base_url'] == 'https://api.example.com/marketdata/v1.0/stock'
         
     def test_base_url_with_path_and_trailing_slash(self):
         # 測試帶有路徑和結尾斜線的 base_url
         client = RestClient(api_key='test-key', base_url='https://api.example.com/api/v2/')
         stock = client.stock
-        assert stock.config['base_url'] == 'https://api.example.com/api/v2/stock'
+        assert stock.config['base_url'] == 'https://api.example.com/api/v2/v1.0/stock'
         futopt = client.futopt
-        assert futopt.config['base_url'] == 'https://api.example.com/api/v2/futopt'
+        assert futopt.config['base_url'] == 'https://api.example.com/api/v2/v1.0/futopt'

--- a/tests/test_websocket_client.py
+++ b/tests/test_websocket_client.py
@@ -20,7 +20,7 @@ def bearer_client():
 
 @pytest.fixture
 def custom_base_url_client():
-    return WebSocketClient(api_key='test-key', base_url='wss://custom-ws.example.com/v2.0')
+    return WebSocketClient(api_key='test-key', base_url='wss://custom-ws.example.com')
 
 
 class TestWebSocketClientConstructor(object):
@@ -46,9 +46,9 @@ class TestWebSocketClientConstructor(object):
 
     def test_with_custom_base_url(self):
         # 測試自訂 base_url 是否正確設定
-        client = WebSocketClient(api_key='api-key', base_url='wss://custom-ws.example.com/v2.0')
+        client = WebSocketClient(api_key='api-key', base_url='wss://custom-ws.example.com')
         assert isinstance(client, WebSocketClient)
-        assert client.options['base_url'] == 'wss://custom-ws.example.com/v2.0'
+        assert client.options['base_url'] == 'wss://custom-ws.example.com'
 
 
 class TestWebSocketClient:
@@ -66,12 +66,12 @@ class TestWebSocketClient:
     def test_stock_with_custom_base_url(self, custom_base_url_client):
         stock = custom_base_url_client.stock
         assert isinstance(stock, WebSocketStockClient)
-        assert stock.config['base_url'] == 'wss://custom-ws.example.com/v2.0/stock/streaming'
+        assert stock.config['base_url'] == 'wss://custom-ws.example.com/v1.0/stock/streaming'
 
     def test_futopt_with_custom_base_url(self, custom_base_url_client):
         futopt = custom_base_url_client.futopt
         assert isinstance(futopt, WebSocketFutOptClient)
-        assert futopt.config['base_url'] == 'wss://custom-ws.example.com/v2.0/futopt/streaming'
+        assert futopt.config['base_url'] == 'wss://custom-ws.example.com/v1.1/futopt/streaming'
 
     def test_stock_and_futopt_different_instances(self, api_key_client):
         stock = api_key_client.stock
@@ -96,27 +96,27 @@ class TestWebSocketClientFactoryUrlConstruction:
     def test_custom_base_url_construction(self, custom_base_url_client):
         # 測試自訂 base_url 的 WebSocket URL 構造
         stock = custom_base_url_client.stock
-        assert stock.config['base_url'] == 'wss://custom-ws.example.com/v2.0/stock/streaming'
+        assert stock.config['base_url'] == 'wss://custom-ws.example.com/v1.0/stock/streaming'
         
         futopt = custom_base_url_client.futopt
-        assert futopt.config['base_url'] == 'wss://custom-ws.example.com/v2.0/futopt/streaming'
+        assert futopt.config['base_url'] == 'wss://custom-ws.example.com/v1.1/futopt/streaming'
 
     def test_url_construction_with_trailing_slash(self):
         # 測試帶有結尾斜線的 base_url，確保沒有雙斜線
-        client = WebSocketClient(api_key='test-key', base_url='wss://ws.example.com/v1/')
+        client = WebSocketClient(api_key='test-key', base_url='wss://ws.example.com/marketdata/')
         stock = client.stock
-        assert stock.config['base_url'] == 'wss://ws.example.com/v1/stock/streaming'
+        assert stock.config['base_url'] == 'wss://ws.example.com/marketdata/v1.0/stock/streaming'
 
     def test_multiple_clients_independent_base_urls(self):
         # 測試多個 WebSocket 客戶端的 base_url 是獨立的
         client1 = WebSocketClient(api_key='key1', base_url='wss://ws1.example.com')
         client2 = WebSocketClient(api_key='key2', base_url='wss://ws2.example.com')
-        
+
         stock1 = client1.stock
         stock2 = client2.stock
-        
-        assert stock1.config['base_url'] == 'wss://ws1.example.com/stock/streaming'
-        assert stock2.config['base_url'] == 'wss://ws2.example.com/stock/streaming'
+
+        assert stock1.config['base_url'] == 'wss://ws1.example.com/v1.0/stock/streaming'
+        assert stock2.config['base_url'] == 'wss://ws2.example.com/v1.0/stock/streaming'
 
 
 class TestWebSocketClientFactoryVersion:
@@ -126,22 +126,27 @@ class TestWebSocketClientFactoryVersion:
         assert api_key_client.futopt.config['base_url'] == f'{self.BASE}/v1.1/futopt/streaming'
         assert api_key_client.stock.config['base_url'] == f'{self.BASE}/v1.0/stock/streaming'
 
-    def test_scalar_version_applies_to_futopt(self):
-        client = WebSocketClient(api_key='api-key', version='v1.1')
+    def test_empty_mapping_matches_no_version_at_all(self):
+        client = WebSocketClient(api_key='api-key', version={})
         assert client.futopt.config['base_url'] == f'{self.BASE}/v1.1/futopt/streaming'
-
-    def test_scalar_version_applies_to_every_product_that_serves_it(self):
-        client = WebSocketClient(api_key='api-key', version='v1.0')
-        assert client.futopt.config['base_url'] == f'{self.BASE}/v1.0/futopt/streaming'
         assert client.stock.config['base_url'] == f'{self.BASE}/v1.0/stock/streaming'
 
-    def test_scalar_version_raises_for_product_that_does_not_serve_it(self):
+    def test_scalar_version_is_rejected(self):
         client = WebSocketClient(api_key='api-key', version='v1.1')
+        with pytest.raises(TypeError) as excinfo:
+            client.futopt
+        assert str(excinfo.value) == (
+            "version must be a per-product mapping, not the bare string 'v1.1'. "
+            "Use version={'futopt': 'v1.1'}."
+        )
+
+    def test_rejected_scalar_names_every_product_that_serves_it(self):
+        client = WebSocketClient(api_key='api-key', version='v1.0')
         with pytest.raises(TypeError) as excinfo:
             client.stock
         assert str(excinfo.value) == (
-            "stock streaming does not support v1.1 (supported: v1.0). "
-            "Use version={'futopt': 'v1.1'} to target a single product."
+            "version must be a per-product mapping, not the bare string 'v1.0'. "
+            "Use version={'stock': 'v1.0', 'futopt': 'v1.0'}."
         )
 
     def test_version_mapping(self):
@@ -159,34 +164,35 @@ class TestWebSocketClientFactoryVersion:
             client.stock
         assert 'stock streaming does not support v1.1' in str(excinfo.value)
 
-    def test_custom_base_url_untouched_without_version(self):
-        client = WebSocketClient(api_key='api-key', base_url='wss://custom-ws.example.com/v2.0')
-        assert client.futopt.config['base_url'] == 'wss://custom-ws.example.com/v2.0/futopt/streaming'
+    def test_custom_base_url_is_versioned_per_product_without_version_option(self):
+        client = WebSocketClient(api_key='api-key', base_url='wss://fubon-api.fugle.tw/marketdata')
+        assert client.futopt.config['base_url'] == 'wss://fubon-api.fugle.tw/marketdata/v1.1/futopt/streaming'
+        assert client.stock.config['base_url'] == 'wss://fubon-api.fugle.tw/marketdata/v1.0/stock/streaming'
 
-    def test_custom_base_url_version_segment_swapped(self):
+    def test_version_option_applies_to_custom_base_url(self):
         client = WebSocketClient(
             api_key='api-key',
-            base_url='wss://api-dev.fugle.tw/marketdata/v1.0',
-            version={'futopt': 'v1.1'},
+            base_url='wss://api-dev.fugle.tw/marketdata',
+            version={'futopt': 'v1.0'},
         )
-        assert client.futopt.config['base_url'] == 'wss://api-dev.fugle.tw/marketdata/v1.1/futopt/streaming'
+        assert client.futopt.config['base_url'] == 'wss://api-dev.fugle.tw/marketdata/v1.0/futopt/streaming'
         assert client.stock.config['base_url'] == 'wss://api-dev.fugle.tw/marketdata/v1.0/stock/streaming'
 
-    def test_custom_base_url_version_segment_swapped_with_trailing_slashes(self):
-        client = WebSocketClient(
-            api_key='api-key',
-            base_url='wss://api-dev.fugle.tw/marketdata/v1.0//',
-            version={'futopt': 'v1.1'},
+    def test_base_url_carrying_a_version_segment_is_rejected(self):
+        client = WebSocketClient(api_key='api-key', base_url='wss://api-dev.fugle.tw/marketdata/v1.0')
+        with pytest.raises(TypeError) as excinfo:
+            client.futopt
+        assert str(excinfo.value) == (
+            "base_url must not include a version segment (found '/v1.0'). "
+            "Pass the host and path prefix only: 'wss://api-dev.fugle.tw/marketdata'. "
+            "The version comes from the `version` option, e.g. version={'futopt': 'v1.1'}."
         )
-        assert client.futopt.config['base_url'] == 'wss://api-dev.fugle.tw/marketdata/v1.1/futopt/streaming'
 
-    def test_custom_base_url_without_version_segment_untouched(self):
-        client = WebSocketClient(
-            api_key='api-key',
-            base_url='wss://ws.example.com/api',
-            version={'futopt': 'v1.1'},
-        )
-        assert client.futopt.config['base_url'] == 'wss://ws.example.com/api/futopt/streaming'
+    def test_versioned_base_url_is_rejected_after_trailing_slashes_are_trimmed(self):
+        client = WebSocketClient(api_key='api-key', base_url='wss://api-dev.fugle.tw/marketdata/v1.0//')
+        with pytest.raises(TypeError) as excinfo:
+            client.futopt
+        assert "base_url must not include a version segment (found '/v1.0')" in str(excinfo.value)
 
 
 class TestWebSocketClientRegressionTests:
@@ -229,29 +235,29 @@ class TestWebSocketClientRegressionTests:
 class TestWebSocketClientUrlNormalization:
     def test_no_trailing_slash_base_url(self):
         # 測試沒有結尾斜線的 base_url
-        client = WebSocketClient(api_key='test-key', base_url='wss://ws.example.com/v1')
+        client = WebSocketClient(api_key='test-key', base_url='wss://ws.example.com/marketdata')
         stock = client.stock
-        assert stock.config['base_url'] == 'wss://ws.example.com/v1/stock/streaming'
-        
+        assert stock.config['base_url'] == 'wss://ws.example.com/marketdata/v1.0/stock/streaming'
+
     def test_single_trailing_slash_base_url(self):
         # 測試單一結尾斜線的 base_url
-        client = WebSocketClient(api_key='test-key', base_url='wss://ws.example.com/v1/')
+        client = WebSocketClient(api_key='test-key', base_url='wss://ws.example.com/marketdata/')
         stock = client.stock
-        assert stock.config['base_url'] == 'wss://ws.example.com/v1/stock/streaming'
-        
+        assert stock.config['base_url'] == 'wss://ws.example.com/marketdata/v1.0/stock/streaming'
+
     def test_multiple_trailing_slashes_base_url(self):
         # 測試多個結尾斜線的 base_url
-        client = WebSocketClient(api_key='test-key', base_url='wss://ws.example.com/v1///')
+        client = WebSocketClient(api_key='test-key', base_url='wss://ws.example.com/marketdata///')
         stock = client.stock
-        assert stock.config['base_url'] == 'wss://ws.example.com/v1/stock/streaming'
-        
-    def test_base_url_with_path_and_trailing_slash(self):
-        # 測試帶有路徑和結尾斜線的 base_url
+        assert stock.config['base_url'] == 'wss://ws.example.com/marketdata/v1.0/stock/streaming'
+
+    def test_non_version_path_segment_stays_part_of_the_prefix(self):
+        # 測試 /api/v2 這種不是 vX.Y 的路徑段會原樣保留在 prefix 裡
         client = WebSocketClient(api_key='test-key', base_url='wss://ws.example.com/api/v2/')
         stock = client.stock
-        assert stock.config['base_url'] == 'wss://ws.example.com/api/v2/stock/streaming'
+        assert stock.config['base_url'] == 'wss://ws.example.com/api/v2/v1.0/stock/streaming'
         futopt = client.futopt
-        assert futopt.config['base_url'] == 'wss://ws.example.com/api/v2/futopt/streaming'
+        assert futopt.config['base_url'] == 'wss://ws.example.com/api/v2/v1.1/futopt/streaming'
 
 
 def _build_health_client(max_missed_pongs=2, ping_interval=30000):


### PR DESCRIPTION
## 問題根源：`base_url` 同時承載 host 和 version

`base_url` 這個字串混了兩個語意：換 host（富邦專屬 endpoint、內部部署、proxy）跟選版本。結果是任何只想換 host 的人，都被迫連 version 一起自己管——這正是我們寫死 `/v1.0` 的原因，不是因為想 pin，而是因為沒有別的方式表達「我只是換 host」。

順著同一條規則，還有三個 RC 階段該修掉的陷阱：

1. **`version=None` 與 `version={}` 行為不同。** 前者保留 URL 裡的版本，後者 per-product resolve 到 latest。同樣是「我沒指定任何產品的版本」，結果不一樣。
2. **`apply_version_to_base_url` 對沒有版本段的 URL 是「留著不動」。** 所以就算傳乾淨的 `wss://fubon-api.fugle.tw/marketdata`，version 選項會被完全忽略——binding 單方面改根本改不動。
3. **scalar 形式 `version='v1.1'` 實質不可用。** 只要取到 `stock` 就必然 raise，而且是 lazy 的、延到取 client 才爆。它只在「這個 factory 我只拿 futopt」時才安全，等於一個看起來通用、實際只在特例成立的 API 形狀。

## 改法：同一個 URL 片段只能有一個 owner

`base_url` 只決定 host / path prefix，版本永遠由 `version` 決定並由 SDK 接上去。SDK 不再 parse `base_url`。

這也是主流 SDK 的分法：Stripe 的 `api_base` 是純 host、版本走 `Stripe-Version`；Anthropic、GitHub 同樣。版本放 path 的（Twilio 的 `/2010-04-01`）也是由 SDK 自己組，使用者永遠不寫那一段。

有個證據說明這本來就是原設計的意圖：`FUGLE_MARKETDATA_API_WEBSOCKET_BASE_URL` 常數本身就是乾淨的 `wss://api.fugle.tw/marketdata`，預設路徑做的正是 `f"{BASE}/{version}"`。偏掉的只有「使用者自己傳 base_url」那條分支——這個 PR 讓兩條分支變成同一條。

### 具體變更

**新增 `fugle_marketdata/base_url.py`** — `with_version(base_url, version, hint='')`，REST / WS 共用：trim 尾端斜線 → 尾端是 `/vX.Y` 就 raise → 否則 `base_url + '/' + version`。沒有 swap、沒有分支。

**`websocket/factory.py`** — `__resolve_base_url` 從兩條路收斂成三行，一律 `resolve_version(product, version)` 再串接。

**`rest/factory.py`** — 同一條規則，用它唯一服務的版本。REST 沒有 `version` 選項，但 base_url 帶版本段一樣 raise。

**`websocket/version.py`** — 移除 scalar 形式，傳字串會直接 raise `TypeError`，訊息會列出所有服務該版本的產品（`Use version={'stock': 'v1.0', 'futopt': 'v1.0'}.`）。`{}` 與 `None` 收斂成同一條路徑。

### 為什麼是 raise 而不是 swap

「尾端有版本段就換掉」看起來相容比較好，但那會**默默改掉使用者指定的 endpoint**——`base_url='.../marketdata/v2.0'` 會被換成 `/v1.1`。純串接則會產生 `.../v2.0/v1.1/...` 這種難以理解的連線失敗。raise 是唯一會明講「你把值放錯旋鈕了」的選項，訊息直接給出該用的 prefix：

```
base_url must not include a version segment (found '/v1.0').
Pass the host and path prefix only: 'wss://api-dev.fugle.tw/marketdata'.
The version comes from the `version` option, e.g. version={'futopt': 'v1.1'}.
```

`version` 選項是 rc.3（兩週前）才進來的，所以「base_url + version 同時給」實質沒有使用者；真正的相容面是舊有「base_url 自帶 `/v1.0`」的寫法，那些人會拿到上面這則訊息。

## 結果

富邦 binding 完全照 official 規則，零特例：

```python
WebSocketClient(api_key=API_KEY, base_url='wss://fubon-api.fugle.tw/marketdata')
# futopt → wss://fubon-api.fugle.tw/marketdata/v1.1/futopt/streaming
# stock  → wss://fubon-api.fugle.tw/marketdata/v1.0/stock/streaming

RestClient(api_key=API_KEY, base_url='https://fubon-api.fugle.tw/marketdata')
# stock  → https://fubon-api.fugle.tw/marketdata/v1.0/stock
```

## Breaking changes

- `base_url` 尾端帶 `/vX.Y` 會 raise `TypeError`。改成只傳 host + path prefix。
- scalar `version='v1.1'` 移除，改用 per-product mapping `version={'futopt': 'v1.1'}`。

⚠️ commit 帶了 `BREAKING CHANGE:` footer，release-it 的 angular preset 會據此推 major bump。若希望留在 2.5 RC 線上，release 時要明確指定版號。

## 測試

127 passed（既有測試全綠）。凡是「base_url 自帶版本段」的期望值都改成乾淨 base_url + 新預期輸出；`URL normalization` 那組保留 trailing-slash 的原意、prefix 換成 `/marketdata`，另外把 `/api/v2` 那個 case 改名為 `test_non_version_path_segment_stays_part_of_the_prefix`，明確釘住 lint 邊界（`/api/v2` 不算版本段，會原樣留在 prefix）。新增涵蓋 `{}` 等同未指定、scalar 被拒、base_url 帶版本段被拒的測試。

未追蹤的 dev harness `test_futopt.py` 也已在本機同步更新（它不在版控裡，不含在這個 PR）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VGBMNGKfgHPyNGMkHMcaJH
