### PR TITLE
feat(client): expose the resolved endpoint on rest and websocket clients

### DIFF
--- a/fugle_marketdata/rest/base_rest.py
+++ b/fugle_marketdata/rest/base_rest.py
@@ -3,6 +3,30 @@ import requests
 from ..exceptions import FugleAPIError
 
 
+class RestProductClient(object):
+    """What a caller holds when they take `.stock` or `.futopt` off the factory.
+
+    The Node SDK gets this for free — its product clients extend `RestClient`.
+    Here the product clients are facades over the endpoint groups rather than
+    `BaseRest` subclasses, so they need a shared ancestor of their own.
+    """
+
+    def __init__(self, **config):
+        # config: base_url, api_key?, bearer_token?
+        self.config = config
+
+    @property
+    def base_url(self):
+        """The prefix every request from this client is built on, fully
+        resolved — host, version segment and product. Endpoints are appended
+        to it.
+
+        The version segment is chosen by the SDK rather than written by the
+        caller, so this is the only way to see what a client resolved to.
+        """
+        return self.config['base_url']
+
+
 class BaseRest(object):
     def __init__(self, **config):
         self.config = config

--- a/fugle_marketdata/rest/futopt/client.py
+++ b/fugle_marketdata/rest/futopt/client.py
@@ -1,13 +1,9 @@
 from .intraday import Intraday
 from .historical import Historical
+from ..base_rest import RestProductClient
 
 
-
-class RestFutOptClient:
-    def __init__(self, **config):
-        # config: base_url, api_key?, bearer_token?
-        self.config = config
-
+class RestFutOptClient(RestProductClient):
     @property
     def intraday(self):
         return Intraday(**self.config)

--- a/fugle_marketdata/rest/stock/client.py
+++ b/fugle_marketdata/rest/stock/client.py
@@ -4,13 +4,10 @@ from .snapshot import Snapshot
 from .technical import Technical
 from .corporate_actions import CorporateActions
 from .ownership import Ownership
+from ..base_rest import RestProductClient
 
 
-class RestStockClient:
-    def __init__(self, **config):
-        # config: base_url, api_key?, bearer_token?
-        self.config = config
-
+class RestStockClient(RestProductClient):
     @property
     def intraday(self):
         return Intraday(**self.config)

--- a/fugle_marketdata/websocket/client.py
+++ b/fugle_marketdata/websocket/client.py
@@ -41,7 +41,7 @@ class WebSocketClient():
         self.ee = EventEmitter()
         self.ee.on(CONNECT_EVENT, self.__authenticate)
         self.__ws = websocket.WebSocketApp(
-            self.config.get('base_url'),
+            self.url,
             on_open=self.__on_open,
             on_close=self.__on_close,
             on_error=self.__on_error,
@@ -57,6 +57,17 @@ class WebSocketClient():
         self.last_message_at = 0.0
         self.last_ping_at = 0.0
         self.__disconnect_reason = None
+
+    @property
+    def url(self):
+        """The endpoint this client connects to, fully resolved — host, version
+        segment, product and `/streaming`.
+
+        The version segment is chosen by the SDK from the `version` option
+        rather than written by the caller, so this is the only way to see which
+        version a client actually ended up on.
+        """
+        return self.config['url']
 
     def ping(self, message):
         message = {

--- a/fugle_marketdata/websocket/factory.py
+++ b/fugle_marketdata/websocket/factory.py
@@ -36,7 +36,11 @@ class WebSocketClientFactory(ClientFactory):
         base_url = self.__resolve_base_url(type)
         url = f'{base_url}/{type}/streaming'
 
-        client_options = {**self.options, 'base_url': url}
+        # The factory's options are not the client's. `base_url` means a host
+        # prefix here and a full endpoint there, so it is dropped rather than
+        # reused under the same name — the client reads `url`.
+        client_options = {**self.options, 'url': url}
+        client_options.pop('base_url', None)
 
         if type == 'stock':
             client = WebSocketStockClient(**client_options)

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -67,7 +67,7 @@ class TestStockRestClient:
     def test_stock_with_custom_base_url(self, custom_base_url_client):
         stock = custom_base_url_client.stock
         assert isinstance(stock, RestStockClient)
-        assert stock.config['base_url'] == 'https://custom-api.example.com/v1.0/stock'
+        assert stock.base_url == 'https://custom-api.example.com/v1.0/stock'
 
     def test_stock_and_futopt_different_instances(self, api_key_client):
         stock = api_key_client.stock
@@ -573,24 +573,24 @@ class TestRestClientFactoryUrlConstruction:
     def test_default_base_url_construction(self, api_key_client):
         # 測試預設 base_url 的 URL 構造
         stock = api_key_client.stock
-        assert stock.config['base_url'] == 'https://api.fugle.tw/marketdata/v1.0/stock'
+        assert stock.base_url == 'https://api.fugle.tw/marketdata/v1.0/stock'
         
         futopt = api_key_client.futopt
-        assert futopt.config['base_url'] == 'https://api.fugle.tw/marketdata/v1.0/futopt'
+        assert futopt.base_url == 'https://api.fugle.tw/marketdata/v1.0/futopt'
 
     def test_custom_base_url_construction(self, custom_base_url_client):
         # 測試自訂 base_url 的 URL 構造
         stock = custom_base_url_client.stock
-        assert stock.config['base_url'] == 'https://custom-api.example.com/v1.0/stock'
+        assert stock.base_url == 'https://custom-api.example.com/v1.0/stock'
         
         futopt = custom_base_url_client.futopt
-        assert futopt.config['base_url'] == 'https://custom-api.example.com/v1.0/futopt'
+        assert futopt.base_url == 'https://custom-api.example.com/v1.0/futopt'
 
     def test_url_construction_with_trailing_slash(self):
         # 測試帶有結尾斜線的 base_url，確保沒有雙斜線
         client = RestClient(api_key='test-key', base_url='https://api.example.com/marketdata/')
         stock = client.stock
-        assert stock.config['base_url'] == 'https://api.example.com/marketdata/v1.0/stock'
+        assert stock.base_url == 'https://api.example.com/marketdata/v1.0/stock'
 
     def test_multiple_clients_independent_base_urls(self):
         # 測試多個客戶端的 base_url 是獨立的
@@ -600,18 +600,18 @@ class TestRestClientFactoryUrlConstruction:
         stock1 = client1.stock
         stock2 = client2.stock
         
-        assert stock1.config['base_url'] == 'https://api1.example.com/v1.0/stock'
-        assert stock2.config['base_url'] == 'https://api2.example.com/v1.0/stock'
+        assert stock1.base_url == 'https://api1.example.com/v1.0/stock'
+        assert stock2.base_url == 'https://api2.example.com/v1.0/stock'
 
 
 class TestRestClientRegressionTests:
     def test_default_behavior_without_base_url(self, api_key_client):
         # 回歸測試：確保不提供 base_url 時使用預設值
         stock = api_key_client.stock
-        assert 'https://api.fugle.tw/marketdata/v1.0/stock' in stock.config['base_url']
+        assert 'https://api.fugle.tw/marketdata/v1.0/stock' in stock.base_url
         
         futopt = api_key_client.futopt
-        assert 'https://api.fugle.tw/marketdata/v1.0/futopt' in futopt.config['base_url']
+        assert 'https://api.fugle.tw/marketdata/v1.0/futopt' in futopt.base_url
 
     def test_api_key_authentication_preserved(self, api_key_client):
         # 回歸測試：確保 API key 認證仍然正常
@@ -648,24 +648,24 @@ class TestRestClientUrlNormalization:
         # 測試沒有結尾斜線的 base_url
         client = RestClient(api_key='test-key', base_url='https://api.example.com/marketdata')
         stock = client.stock
-        assert stock.config['base_url'] == 'https://api.example.com/marketdata/v1.0/stock'
+        assert stock.base_url == 'https://api.example.com/marketdata/v1.0/stock'
         
     def test_single_trailing_slash_base_url(self):
         # 測試單一結尾斜線的 base_url
         client = RestClient(api_key='test-key', base_url='https://api.example.com/marketdata/')
         stock = client.stock
-        assert stock.config['base_url'] == 'https://api.example.com/marketdata/v1.0/stock'
+        assert stock.base_url == 'https://api.example.com/marketdata/v1.0/stock'
         
     def test_multiple_trailing_slashes_base_url(self):
         # 測試多個結尾斜線的 base_url
         client = RestClient(api_key='test-key', base_url='https://api.example.com/marketdata///')
         stock = client.stock
-        assert stock.config['base_url'] == 'https://api.example.com/marketdata/v1.0/stock'
+        assert stock.base_url == 'https://api.example.com/marketdata/v1.0/stock'
         
     def test_base_url_with_path_and_trailing_slash(self):
         # 測試帶有路徑和結尾斜線的 base_url
         client = RestClient(api_key='test-key', base_url='https://api.example.com/api/v2/')
         stock = client.stock
-        assert stock.config['base_url'] == 'https://api.example.com/api/v2/v1.0/stock'
+        assert stock.base_url == 'https://api.example.com/api/v2/v1.0/stock'
         futopt = client.futopt
-        assert futopt.config['base_url'] == 'https://api.example.com/api/v2/v1.0/futopt'
+        assert futopt.base_url == 'https://api.example.com/api/v2/v1.0/futopt'

--- a/tests/test_websocket_client.py
+++ b/tests/test_websocket_client.py
@@ -66,12 +66,12 @@ class TestWebSocketClient:
     def test_stock_with_custom_base_url(self, custom_base_url_client):
         stock = custom_base_url_client.stock
         assert isinstance(stock, WebSocketStockClient)
-        assert stock.config['base_url'] == 'wss://custom-ws.example.com/v1.0/stock/streaming'
+        assert stock.url == 'wss://custom-ws.example.com/v1.0/stock/streaming'
 
     def test_futopt_with_custom_base_url(self, custom_base_url_client):
         futopt = custom_base_url_client.futopt
         assert isinstance(futopt, WebSocketFutOptClient)
-        assert futopt.config['base_url'] == 'wss://custom-ws.example.com/v1.1/futopt/streaming'
+        assert futopt.url == 'wss://custom-ws.example.com/v1.1/futopt/streaming'
 
     def test_stock_and_futopt_different_instances(self, api_key_client):
         stock = api_key_client.stock
@@ -88,24 +88,24 @@ class TestWebSocketClientFactoryUrlConstruction:
     def test_default_base_url_construction(self, api_key_client):
         # 測試預設 base_url 的 WebSocket URL 構造
         stock = api_key_client.stock
-        assert stock.config['base_url'] == 'wss://api.fugle.tw/marketdata/v1.0/stock/streaming'
+        assert stock.url == 'wss://api.fugle.tw/marketdata/v1.0/stock/streaming'
         
         futopt = api_key_client.futopt
-        assert futopt.config['base_url'] == 'wss://api.fugle.tw/marketdata/v1.1/futopt/streaming'
+        assert futopt.url == 'wss://api.fugle.tw/marketdata/v1.1/futopt/streaming'
 
     def test_custom_base_url_construction(self, custom_base_url_client):
         # 測試自訂 base_url 的 WebSocket URL 構造
         stock = custom_base_url_client.stock
-        assert stock.config['base_url'] == 'wss://custom-ws.example.com/v1.0/stock/streaming'
+        assert stock.url == 'wss://custom-ws.example.com/v1.0/stock/streaming'
         
         futopt = custom_base_url_client.futopt
-        assert futopt.config['base_url'] == 'wss://custom-ws.example.com/v1.1/futopt/streaming'
+        assert futopt.url == 'wss://custom-ws.example.com/v1.1/futopt/streaming'
 
     def test_url_construction_with_trailing_slash(self):
         # 測試帶有結尾斜線的 base_url，確保沒有雙斜線
         client = WebSocketClient(api_key='test-key', base_url='wss://ws.example.com/marketdata/')
         stock = client.stock
-        assert stock.config['base_url'] == 'wss://ws.example.com/marketdata/v1.0/stock/streaming'
+        assert stock.url == 'wss://ws.example.com/marketdata/v1.0/stock/streaming'
 
     def test_multiple_clients_independent_base_urls(self):
         # 測試多個 WebSocket 客戶端的 base_url 是獨立的
@@ -115,21 +115,21 @@ class TestWebSocketClientFactoryUrlConstruction:
         stock1 = client1.stock
         stock2 = client2.stock
 
-        assert stock1.config['base_url'] == 'wss://ws1.example.com/v1.0/stock/streaming'
-        assert stock2.config['base_url'] == 'wss://ws2.example.com/v1.0/stock/streaming'
+        assert stock1.url == 'wss://ws1.example.com/v1.0/stock/streaming'
+        assert stock2.url == 'wss://ws2.example.com/v1.0/stock/streaming'
 
 
 class TestWebSocketClientFactoryVersion:
     BASE = 'wss://api.fugle.tw/marketdata'
 
     def test_defaults_to_each_product_latest(self, api_key_client):
-        assert api_key_client.futopt.config['base_url'] == f'{self.BASE}/v1.1/futopt/streaming'
-        assert api_key_client.stock.config['base_url'] == f'{self.BASE}/v1.0/stock/streaming'
+        assert api_key_client.futopt.url == f'{self.BASE}/v1.1/futopt/streaming'
+        assert api_key_client.stock.url == f'{self.BASE}/v1.0/stock/streaming'
 
     def test_empty_mapping_matches_no_version_at_all(self):
         client = WebSocketClient(api_key='api-key', version={})
-        assert client.futopt.config['base_url'] == f'{self.BASE}/v1.1/futopt/streaming'
-        assert client.stock.config['base_url'] == f'{self.BASE}/v1.0/stock/streaming'
+        assert client.futopt.url == f'{self.BASE}/v1.1/futopt/streaming'
+        assert client.stock.url == f'{self.BASE}/v1.0/stock/streaming'
 
     def test_scalar_version_is_rejected(self):
         client = WebSocketClient(api_key='api-key', version='v1.1')
@@ -151,12 +151,12 @@ class TestWebSocketClientFactoryVersion:
 
     def test_version_mapping(self):
         client = WebSocketClient(api_key='api-key', version={'futopt': 'v1.1'})
-        assert client.futopt.config['base_url'] == f'{self.BASE}/v1.1/futopt/streaming'
-        assert client.stock.config['base_url'] == f'{self.BASE}/v1.0/stock/streaming'
+        assert client.futopt.url == f'{self.BASE}/v1.1/futopt/streaming'
+        assert client.stock.url == f'{self.BASE}/v1.0/stock/streaming'
 
     def test_version_mapping_pins_futopt_back_to_v1_0(self):
         client = WebSocketClient(api_key='api-key', version={'futopt': 'v1.0'})
-        assert client.futopt.config['base_url'] == f'{self.BASE}/v1.0/futopt/streaming'
+        assert client.futopt.url == f'{self.BASE}/v1.0/futopt/streaming'
 
     def test_version_mapping_raises_for_unsupported_pair(self):
         client = WebSocketClient(api_key='api-key', version={'stock': 'v1.1'})
@@ -166,8 +166,8 @@ class TestWebSocketClientFactoryVersion:
 
     def test_custom_base_url_is_versioned_per_product_without_version_option(self):
         client = WebSocketClient(api_key='api-key', base_url='wss://fubon-api.fugle.tw/marketdata')
-        assert client.futopt.config['base_url'] == 'wss://fubon-api.fugle.tw/marketdata/v1.1/futopt/streaming'
-        assert client.stock.config['base_url'] == 'wss://fubon-api.fugle.tw/marketdata/v1.0/stock/streaming'
+        assert client.futopt.url == 'wss://fubon-api.fugle.tw/marketdata/v1.1/futopt/streaming'
+        assert client.stock.url == 'wss://fubon-api.fugle.tw/marketdata/v1.0/stock/streaming'
 
     def test_version_option_applies_to_custom_base_url(self):
         client = WebSocketClient(
@@ -175,8 +175,8 @@ class TestWebSocketClientFactoryVersion:
             base_url='wss://api-dev.fugle.tw/marketdata',
             version={'futopt': 'v1.0'},
         )
-        assert client.futopt.config['base_url'] == 'wss://api-dev.fugle.tw/marketdata/v1.0/futopt/streaming'
-        assert client.stock.config['base_url'] == 'wss://api-dev.fugle.tw/marketdata/v1.0/stock/streaming'
+        assert client.futopt.url == 'wss://api-dev.fugle.tw/marketdata/v1.0/futopt/streaming'
+        assert client.stock.url == 'wss://api-dev.fugle.tw/marketdata/v1.0/stock/streaming'
 
     def test_base_url_carrying_a_version_segment_is_rejected(self):
         client = WebSocketClient(api_key='api-key', base_url='wss://api-dev.fugle.tw/marketdata/v1.0')
@@ -199,10 +199,10 @@ class TestWebSocketClientRegressionTests:
     def test_default_behavior_without_base_url(self, api_key_client):
         # 回歸測試：確保不提供 base_url 時使用預設值
         stock = api_key_client.stock
-        assert 'wss://api.fugle.tw/marketdata/v1.0/stock/streaming' in stock.config['base_url']
+        assert 'wss://api.fugle.tw/marketdata/v1.0/stock/streaming' in stock.url
         
         futopt = api_key_client.futopt
-        assert 'wss://api.fugle.tw/marketdata/v1.1/futopt/streaming' in futopt.config['base_url']
+        assert 'wss://api.fugle.tw/marketdata/v1.1/futopt/streaming' in futopt.url
 
     def test_api_key_authentication_preserved(self, api_key_client):
         # 回歸測試：確保 API key 認證仍然正常
@@ -237,27 +237,27 @@ class TestWebSocketClientUrlNormalization:
         # 測試沒有結尾斜線的 base_url
         client = WebSocketClient(api_key='test-key', base_url='wss://ws.example.com/marketdata')
         stock = client.stock
-        assert stock.config['base_url'] == 'wss://ws.example.com/marketdata/v1.0/stock/streaming'
+        assert stock.url == 'wss://ws.example.com/marketdata/v1.0/stock/streaming'
 
     def test_single_trailing_slash_base_url(self):
         # 測試單一結尾斜線的 base_url
         client = WebSocketClient(api_key='test-key', base_url='wss://ws.example.com/marketdata/')
         stock = client.stock
-        assert stock.config['base_url'] == 'wss://ws.example.com/marketdata/v1.0/stock/streaming'
+        assert stock.url == 'wss://ws.example.com/marketdata/v1.0/stock/streaming'
 
     def test_multiple_trailing_slashes_base_url(self):
         # 測試多個結尾斜線的 base_url
         client = WebSocketClient(api_key='test-key', base_url='wss://ws.example.com/marketdata///')
         stock = client.stock
-        assert stock.config['base_url'] == 'wss://ws.example.com/marketdata/v1.0/stock/streaming'
+        assert stock.url == 'wss://ws.example.com/marketdata/v1.0/stock/streaming'
 
     def test_non_version_path_segment_stays_part_of_the_prefix(self):
         # 測試 /api/v2 這種不是 vX.Y 的路徑段會原樣保留在 prefix 裡
         client = WebSocketClient(api_key='test-key', base_url='wss://ws.example.com/api/v2/')
         stock = client.stock
-        assert stock.config['base_url'] == 'wss://ws.example.com/api/v2/v1.0/stock/streaming'
+        assert stock.url == 'wss://ws.example.com/api/v2/v1.0/stock/streaming'
         futopt = client.futopt
-        assert futopt.config['base_url'] == 'wss://ws.example.com/api/v2/v1.1/futopt/streaming'
+        assert futopt.url == 'wss://ws.example.com/api/v2/v1.1/futopt/streaming'
 
 
 def _build_health_client(max_missed_pongs=2, ping_interval=30000):
@@ -270,7 +270,7 @@ def _build_health_client(max_missed_pongs=2, ping_interval=30000):
         max_missed_pongs=max_missed_pongs,
     )
     client = CoreWebSocketClient(
-        base_url='wss://ws.example.com/stock/streaming',
+        url='wss://ws.example.com/stock/streaming',
         api_key='api-key',
         health_check=health,
     )
@@ -403,7 +403,7 @@ class TestWebSocketHealthCheck:
         # Use a real (un-stubbed) core client to check on_close threading.
         health = HealthCheckConfig(enabled=True)
         client = CoreWebSocketClient(
-            base_url='wss://ws.example.com/stock/streaming',
+            url='wss://ws.example.com/stock/streaming',
             api_key='api-key',
             health_check=health,
         )
@@ -415,3 +415,14 @@ class TestWebSocketHealthCheck:
         assert received['args'] == (1000, 'normal')
         # Only two args: no reason payload.
         assert len(received['args']) == 2
+
+
+class TestWebSocketClientConfigKeys:
+    # `url` 本身由上面每一組 URL 測試涵蓋——它們都是讀 `.url` 斷言的。
+    # 這裡釘住的是 factory 不會把自己的 `base_url` 語意漏進 client。
+    def test_client_config_carries_the_endpoint_under_url_only(self):
+        futopt = WebSocketClient(api_key='api-key', base_url='wss://ws.example.com/marketdata').futopt
+        assert futopt.config['url'] == futopt.url
+        # factory 的 `base_url` 是 host prefix，跟 client 的完整 endpoint 同名異義，
+        # 所以不沿用——留著會是個看起來合理、意思卻不同的值。
+        assert 'base_url' not in futopt.config


### PR DESCRIPTION
## 為什麼需要這個

rc4 把 `base_url` 收斂成「只決定 host / path prefix」之後，版本段改由 SDK 決定。這是對的分工，但它**拿走了使用者原本自然擁有的資訊**——以前版本是他自己寫進 URL 的，現在他問不出「我實際上跑在哪個版本」。

Python 這邊唯一的出路是去挖 config dict（`client.futopt.config['base_url']`），沒有文件、沒有保證，而且那個 key 名字還是錯的：它裝的是**完整 URL**（含 `/futopt/streaming`），根本不是 base。

## 加了什麼

| | 回傳 |
|---|---|
| `WebSocketClient.url` | 完整 endpoint，含版本段與 `/streaming` |
| `RestStockClient.base_url` / `RestFutOptClient.base_url` | 請求組裝的 prefix，含版本段與 product |

```python
client = WebSocketClient(api_key=API_KEY, base_url='wss://fubon-api.fugle.tw/marketdata')
client.futopt.url  # wss://fubon-api.fugle.tw/marketdata/v1.1/futopt/streaming
client.stock.url   # wss://fubon-api.fugle.tw/marketdata/v1.0/stock/streaming

RestClient(api_key=API_KEY).stock.base_url
# https://api.fugle.tw/marketdata/v1.0/stock
```

兩個都是唯讀、連線前就讀得到（取 `.futopt` 只建物件不連線）。

## 兩個結構上的決定

**WS config key 收斂成只有 `url`，`base_url` 不再傳給 client。**

factory 原本是 `{**self.options, 'base_url': url}`——注意 `self.options` 裡本來就有使用者傳的 `base_url`（host prefix），是後面那個賦值把它蓋成完整 endpoint。

所以「拿掉 alias」不能只是不寫那個 key：那樣 `config['base_url']` 不會消失，它會變回**使用者傳進來的 host prefix**。同名、看起來一樣合理、意思卻不同。改成主動剔除：

```python
client_options = {**self.options, 'url': url}
client_options.pop('base_url', None)
```

`config` 從來不是文件上的公開 API，而且**沒有任何已發布版本同時有 `.url` 和這個 key**——rc4 兩個都沒有。所以現在做等於那個承諾從來沒發生過，不需要 deprecation window。真的有人在讀舊 key，遷移就是換成 `.url`，值一模一樣。

REST 那邊的 `base_url` 保留不動——在那裡名字是對的，它真的是 base。

**新增 `RestProductClient` 作為 product client 的共同祖先。**

Node 那邊 `RestStockClient` / `RestFutOptClient` 都 `extends RestClient`，所以加一個 getter 就全繼承到了。Python 沒有這層——這兩個是 endpoint group 的 facade，**不是** `BaseRest` 的子類別（`BaseRest` 其實是 `Intraday`、`Historical` 那些葉節點的父類別）。

第一版我把 property 貼了三份（`BaseRest` + 兩個 product client）才讓測試綠。`/simplify` 抓出這點，改成建一個 `RestProductClient` 放共用的 `__init__` 和 `base_url`，兩個 product client 繼承它。順帶修掉兩件事：

- 三份會漂移的 docstring 收斂成一份（第一版就已經漂了，`BaseRest` 那份多一句話）
- `base_url` 不再意外長在每個子資源上（`client.stock.intraday.base_url` 這種沒人要求、也沒測試的表面積）

這也讓兩邊 SDK 的結構對上：一個共同祖先，一個 accessor。

## 設計取捨

**放 client 不放 factory。** 「連到哪」是 client 的性質。放 factory 會變成 `client.url_for('futopt')`，但 product 在你拿到 `client.futopt` 的當下就確定了。

**WS 叫 `url`，REST 叫 `base_url`。** REST 那個真的是 base——endpoint 會往後接；WS 那個是完整位址。

**只給 URL，不給 `version`。** 討論過是否另開 `client.futopt.version == 'v1.1'`。完整 URL 在 debug 時資訊更足，而單獨的 `version` 需求目前還沒有人提。

## 測試

128 passed。既有的 URL 斷言全部改讀公開 accessor（`.url` / `.base_url`），等於用既有測試證明這條路是通的。

只另外加了一個測試，釘住 client config 只帶 `url`、不帶 `base_url`——那是唯一沒被既有測試涵蓋的東西。原本還寫了三個 accessor 專用測試，`/simplify` 指出它們跟改寫過的既有測試一字不差，已刪除。

兩處直接建構低階 `WebSocketClient` 的測試（health check 用）改成傳 `url=`。該類別不在 `__all__` 裡。

## 相關

延續 #22（`base_url` 與版本分離）。這個 PR 補的是那次改動留下的可見性缺口。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VGBMNGKfgHPyNGMkHMcaJH
