### PR TITLE
feat: add stock ownership institutional_trades, director_holdings & tdcc_distribution REST endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [2.6.0rc1](https://github.com/fugle-dev/fugle-marketdata-python/compare/2.5.0...2.6.0rc1) (2026-08-20)
+
+
+### Features
+
+* add stock ownership institutional_trades, director_holdings & tdcc_distribution REST endpoints ([b265df1](https://github.com/fugle-dev/fugle-marketdata-python/commit/b265df140aecb68a83baf96f506cb71d8ad29b2d))
+
+
+### Bug Fixes
+
+* accept `from_` as an alias for the reserved-word `from` query param in REST requests ([b265df1](https://github.com/fugle-dev/fugle-marketdata-python/commit/b265df140aecb68a83baf96f506cb71d8ad29b2d))
+
 ## [2.5.0](https://github.com/fugle-dev/fugle-marketdata-python/compare/2.4.1...2.5.0) (2026-08-14)
 
 

--- a/fugle_marketdata/__init__.py
+++ b/fugle_marketdata/__init__.py
@@ -2,6 +2,6 @@ from .rest import RestClientFactory as RestClient
 from .websocket import WebSocketClientFactory as WebSocketClient, HealthCheckConfig
 from .exceptions import FugleAPIError
 
-__version__ = '2.5.0'
+__version__ = '2.6.0rc1'
 
 __all__ = ['RestClient', 'WebSocketClient', 'HealthCheckConfig', 'FugleAPIError', '__version__']

--- a/fugle_marketdata/rest/base_rest.py
+++ b/fugle_marketdata/rest/base_rest.py
@@ -43,6 +43,10 @@ class BaseRest(object):
 
         endpoint = path if (path.startswith('/')) else '/' + path
 
+        # `from` is a reserved keyword in Python; accept `from_` as an alias.
+        if 'from_' in params:
+            params['from'] = params.pop('from_')
+
         if len(params) == 0:
             query = ''
         else:

--- a/fugle_marketdata/rest/stock/ownership.py
+++ b/fugle_marketdata/rest/stock/ownership.py
@@ -5,3 +5,15 @@ class Ownership(BaseRest):
     def etf_holdings(self, **params):
         symbol = params.pop('symbol')
         return self.request(f"ownership/etf-holdings/{symbol}", **params)
+
+    def institutional_trades(self, **params):
+        symbol = params.pop('symbol')
+        return self.request(f"ownership/institutional-trades/{symbol}", **params)
+
+    def director_holdings(self, **params):
+        symbol = params.pop('symbol')
+        return self.request(f"ownership/director-holdings/{symbol}", **params)
+
+    def tdcc_distribution(self, **params):
+        symbol = params.pop('symbol')
+        return self.request(f"ownership/tdcc-distribution/{symbol}", **params)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fugle-marketdata"
-version = "2.5.0"
+version = "2.6.0rc1"
 description = "Fugle Realtime API 1.0 client library for Python"
 authors = ["Fortuna Intelligence Co., Ltd. <development@fugle.tw>"]
 license = "MIT"

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -230,6 +230,9 @@ class TestStockRestOwnershipClient:
     def test_stock_ownership(self, api_key_client):
         stock = api_key_client.stock
         assert hasattr(stock.ownership, 'etf_holdings')
+        assert hasattr(stock.ownership, 'institutional_trades')
+        assert hasattr(stock.ownership, 'director_holdings')
+        assert hasattr(stock.ownership, 'tdcc_distribution')
 
     def test_ownership_etf_holdings_api_key(self, mocker, api_key_client):
         stock = api_key_client.stock
@@ -258,6 +261,96 @@ class TestStockRestOwnershipClient:
         stock.ownership.etf_holdings(symbol='0050', **{'from': '2026-05-01'}, to='2026-05-21', sort='desc')
         mock_get.assert_called_once_with(
             'https://api.fugle.tw/marketdata/v1.0/stock/ownership/etf-holdings/0050?from=2026-05-01&to=2026-05-21&sort=desc',
+            headers={'X-API-KEY': 'api-key'}
+        )
+
+    def test_ownership_institutional_trades_api_key(self, mocker, api_key_client):
+        stock = api_key_client.stock
+        mock_get = mocker.patch('requests.get')
+        mock_get.return_value.status_code = 200
+        stock.ownership.institutional_trades(symbol='2330')
+        mock_get.assert_called_once_with(
+            'https://api.fugle.tw/marketdata/v1.0/stock/ownership/institutional-trades/2330',
+            headers={'X-API-KEY': 'api-key'}
+        )
+
+    def test_ownership_institutional_trades_bearer_token(self, bearer_client, mocker):
+        stock = bearer_client.stock
+        mock_get = mocker.patch('requests.get')
+        mock_get.return_value.status_code = 200
+        stock.ownership.institutional_trades(symbol='2330')
+        mock_get.assert_called_once_with(
+            'https://api.fugle.tw/marketdata/v1.0/stock/ownership/institutional-trades/2330',
+            headers={'Authorization': 'Bearer bearer-token'}
+        )
+
+    def test_ownership_institutional_trades_query_params(self, mocker, api_key_client):
+        stock = api_key_client.stock
+        mock_get = mocker.patch('requests.get')
+        mock_get.return_value.status_code = 200
+        stock.ownership.institutional_trades(symbol='2330', from_='2026-07-01', to='2026-07-31', sort='desc')
+        mock_get.assert_called_once_with(
+            'https://api.fugle.tw/marketdata/v1.0/stock/ownership/institutional-trades/2330?to=2026-07-31&sort=desc&from=2026-07-01',
+            headers={'X-API-KEY': 'api-key'}
+        )
+
+    def test_ownership_director_holdings_api_key(self, mocker, api_key_client):
+        stock = api_key_client.stock
+        mock_get = mocker.patch('requests.get')
+        mock_get.return_value.status_code = 200
+        stock.ownership.director_holdings(symbol='2330')
+        mock_get.assert_called_once_with(
+            'https://api.fugle.tw/marketdata/v1.0/stock/ownership/director-holdings/2330',
+            headers={'X-API-KEY': 'api-key'}
+        )
+
+    def test_ownership_director_holdings_bearer_token(self, bearer_client, mocker):
+        stock = bearer_client.stock
+        mock_get = mocker.patch('requests.get')
+        mock_get.return_value.status_code = 200
+        stock.ownership.director_holdings(symbol='2330')
+        mock_get.assert_called_once_with(
+            'https://api.fugle.tw/marketdata/v1.0/stock/ownership/director-holdings/2330',
+            headers={'Authorization': 'Bearer bearer-token'}
+        )
+
+    def test_ownership_director_holdings_query_params(self, mocker, api_key_client):
+        stock = api_key_client.stock
+        mock_get = mocker.patch('requests.get')
+        mock_get.return_value.status_code = 200
+        stock.ownership.director_holdings(symbol='2330', from_='2026-01-01', to='2026-05-31', sort='desc')
+        mock_get.assert_called_once_with(
+            'https://api.fugle.tw/marketdata/v1.0/stock/ownership/director-holdings/2330?to=2026-05-31&sort=desc&from=2026-01-01',
+            headers={'X-API-KEY': 'api-key'}
+        )
+
+    def test_ownership_tdcc_distribution_api_key(self, mocker, api_key_client):
+        stock = api_key_client.stock
+        mock_get = mocker.patch('requests.get')
+        mock_get.return_value.status_code = 200
+        stock.ownership.tdcc_distribution(symbol='2330')
+        mock_get.assert_called_once_with(
+            'https://api.fugle.tw/marketdata/v1.0/stock/ownership/tdcc-distribution/2330',
+            headers={'X-API-KEY': 'api-key'}
+        )
+
+    def test_ownership_tdcc_distribution_bearer_token(self, bearer_client, mocker):
+        stock = bearer_client.stock
+        mock_get = mocker.patch('requests.get')
+        mock_get.return_value.status_code = 200
+        stock.ownership.tdcc_distribution(symbol='2330')
+        mock_get.assert_called_once_with(
+            'https://api.fugle.tw/marketdata/v1.0/stock/ownership/tdcc-distribution/2330',
+            headers={'Authorization': 'Bearer bearer-token'}
+        )
+
+    def test_ownership_tdcc_distribution_query_params(self, mocker, api_key_client):
+        stock = api_key_client.stock
+        mock_get = mocker.patch('requests.get')
+        mock_get.return_value.status_code = 200
+        stock.ownership.tdcc_distribution(symbol='2330', from_='2026-06-01', to='2026-07-03', sort='desc')
+        mock_get.assert_called_once_with(
+            'https://api.fugle.tw/marketdata/v1.0/stock/ownership/tdcc-distribution/2330?to=2026-07-03&sort=desc&from=2026-06-01',
             headers={'X-API-KEY': 'api-key'}
         )
 


### PR DESCRIPTION
## Summary
Wraps three new v1.0 \`/stock/ownership/*\` endpoints that are live on fugle-realtime (#623 三大法人, #642 董監持股, #641 集保分布). Same \`from\` / \`to\` / \`sort\` query contract as the existing \`etf_holdings\`.

- \`stock.ownership.institutional_trades(symbol=...)\` → \`ownership/institutional-trades/:symbol\`
- \`stock.ownership.director_holdings(symbol=...)\` → \`ownership/director-holdings/:symbol\`
- \`stock.ownership.tdcc_distribution(symbol=...)\` → \`ownership/tdcc-distribution/:symbol\`

Also fixes \`from_\`: \`BaseRest.request\` now rewrites \`from_\` → \`from\` before sending. Previously it went out verbatim as \`?from_=\` and was silently ignored by the server, even though the README documented \`from_\` as the way to pass the reserved-word param.

## Test plan
- [x] \`pytest\` — 137 passed (+9 new cases, query-param cases exercise the \`from_\` alias)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DSkx8KegwNXgz4EDgdEcQa